### PR TITLE
Peertube support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1767,7 +1767,7 @@ dependencies = [
 [[package]]
 name = "tf_core"
 version = "0.1.0"
-source = "git+https://github.com/Tubefeeder/tubefeeder-extractor.git?rev=f697eecb893f0761d89df9ce2763a87d6a0f01df#f697eecb893f0761d89df9ce2763a87d6a0f01df"
+source = "git+https://github.com/Tubefeeder/tubefeeder-extractor.git?branch=platform-peertube#326a93f3edd436b9c7b30d8884328ce9ce671aa5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1784,7 +1784,7 @@ dependencies = [
 [[package]]
 name = "tf_filter"
 version = "0.1.0"
-source = "git+https://github.com/Tubefeeder/tubefeeder-extractor.git?rev=f697eecb893f0761d89df9ce2763a87d6a0f01df#f697eecb893f0761d89df9ce2763a87d6a0f01df"
+source = "git+https://github.com/Tubefeeder/tubefeeder-extractor.git?branch=platform-peertube#326a93f3edd436b9c7b30d8884328ce9ce671aa5"
 dependencies = [
  "log",
  "tf_observer",
@@ -1793,7 +1793,7 @@ dependencies = [
 [[package]]
 name = "tf_join"
 version = "0.1.0"
-source = "git+https://github.com/Tubefeeder/tubefeeder-extractor.git?rev=f697eecb893f0761d89df9ce2763a87d6a0f01df#f697eecb893f0761d89df9ce2763a87d6a0f01df"
+source = "git+https://github.com/Tubefeeder/tubefeeder-extractor.git?branch=platform-peertube#326a93f3edd436b9c7b30d8884328ce9ce671aa5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1805,6 +1805,7 @@ dependencies = [
  "tf_core",
  "tf_filter",
  "tf_observer",
+ "tf_platform_peertube",
  "tf_platform_youtube",
  "tokio",
 ]
@@ -1812,12 +1813,30 @@ dependencies = [
 [[package]]
 name = "tf_observer"
 version = "0.1.0"
-source = "git+https://github.com/Tubefeeder/tubefeeder-extractor.git?rev=f697eecb893f0761d89df9ce2763a87d6a0f01df#f697eecb893f0761d89df9ce2763a87d6a0f01df"
+source = "git+https://github.com/Tubefeeder/tubefeeder-extractor.git?branch=platform-peertube#326a93f3edd436b9c7b30d8884328ce9ce671aa5"
+
+[[package]]
+name = "tf_platform_peertube"
+version = "0.0.0"
+source = "git+https://github.com/Tubefeeder/tubefeeder-extractor.git?branch=platform-peertube#326a93f3edd436b9c7b30d8884328ce9ce671aa5"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "gdk-pixbuf",
+ "gio",
+ "glib",
+ "log",
+ "quick-xml",
+ "reqwest",
+ "serde",
+ "tf_core",
+ "tokio",
+]
 
 [[package]]
 name = "tf_platform_youtube"
 version = "0.1.0"
-source = "git+https://github.com/Tubefeeder/tubefeeder-extractor.git?rev=f697eecb893f0761d89df9ce2763a87d6a0f01df#f697eecb893f0761d89df9ce2763a87d6a0f01df"
+source = "git+https://github.com/Tubefeeder/tubefeeder-extractor.git?branch=platform-peertube#326a93f3edd436b9c7b30d8884328ce9ce671aa5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1837,7 +1856,7 @@ dependencies = [
 [[package]]
 name = "tf_playlist"
 version = "0.1.1"
-source = "git+https://github.com/Tubefeeder/tubefeeder-extractor.git?rev=f697eecb893f0761d89df9ce2763a87d6a0f01df#f697eecb893f0761d89df9ce2763a87d6a0f01df"
+source = "git+https://github.com/Tubefeeder/tubefeeder-extractor.git?branch=platform-peertube#326a93f3edd436b9c7b30d8884328ce9ce671aa5"
 dependencies = [
  "log",
  "tf_observer",
@@ -1998,7 +2017,7 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "tubefeeder"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "chrono",
  "csv",
@@ -2019,6 +2038,7 @@ dependencies = [
  "tf_filter",
  "tf_join",
  "tf_observer",
+ "tf_platform_peertube",
  "tf_platform_youtube",
  "tf_playlist",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1767,7 +1767,7 @@ dependencies = [
 [[package]]
 name = "tf_core"
 version = "0.1.0"
-source = "git+https://github.com/Tubefeeder/tubefeeder-extractor.git?branch=platform-peertube#326a93f3edd436b9c7b30d8884328ce9ce671aa5"
+source = "git+https://github.com/Tubefeeder/tubefeeder-extractor.git?rev=a8470b66031ef85485e42ce5e649a0dad715adfb#a8470b66031ef85485e42ce5e649a0dad715adfb"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1784,7 +1784,7 @@ dependencies = [
 [[package]]
 name = "tf_filter"
 version = "0.1.0"
-source = "git+https://github.com/Tubefeeder/tubefeeder-extractor.git?branch=platform-peertube#326a93f3edd436b9c7b30d8884328ce9ce671aa5"
+source = "git+https://github.com/Tubefeeder/tubefeeder-extractor.git?rev=a8470b66031ef85485e42ce5e649a0dad715adfb#a8470b66031ef85485e42ce5e649a0dad715adfb"
 dependencies = [
  "log",
  "tf_observer",
@@ -1793,7 +1793,7 @@ dependencies = [
 [[package]]
 name = "tf_join"
 version = "0.1.0"
-source = "git+https://github.com/Tubefeeder/tubefeeder-extractor.git?branch=platform-peertube#326a93f3edd436b9c7b30d8884328ce9ce671aa5"
+source = "git+https://github.com/Tubefeeder/tubefeeder-extractor.git?rev=a8470b66031ef85485e42ce5e649a0dad715adfb#a8470b66031ef85485e42ce5e649a0dad715adfb"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1813,12 +1813,12 @@ dependencies = [
 [[package]]
 name = "tf_observer"
 version = "0.1.0"
-source = "git+https://github.com/Tubefeeder/tubefeeder-extractor.git?branch=platform-peertube#326a93f3edd436b9c7b30d8884328ce9ce671aa5"
+source = "git+https://github.com/Tubefeeder/tubefeeder-extractor.git?rev=a8470b66031ef85485e42ce5e649a0dad715adfb#a8470b66031ef85485e42ce5e649a0dad715adfb"
 
 [[package]]
 name = "tf_platform_peertube"
 version = "0.0.0"
-source = "git+https://github.com/Tubefeeder/tubefeeder-extractor.git?branch=platform-peertube#326a93f3edd436b9c7b30d8884328ce9ce671aa5"
+source = "git+https://github.com/Tubefeeder/tubefeeder-extractor.git?rev=a8470b66031ef85485e42ce5e649a0dad715adfb#a8470b66031ef85485e42ce5e649a0dad715adfb"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1836,7 +1836,7 @@ dependencies = [
 [[package]]
 name = "tf_platform_youtube"
 version = "0.1.0"
-source = "git+https://github.com/Tubefeeder/tubefeeder-extractor.git?branch=platform-peertube#326a93f3edd436b9c7b30d8884328ce9ce671aa5"
+source = "git+https://github.com/Tubefeeder/tubefeeder-extractor.git?rev=a8470b66031ef85485e42ce5e649a0dad715adfb#a8470b66031ef85485e42ce5e649a0dad715adfb"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1856,7 +1856,7 @@ dependencies = [
 [[package]]
 name = "tf_playlist"
 version = "0.1.1"
-source = "git+https://github.com/Tubefeeder/tubefeeder-extractor.git?branch=platform-peertube#326a93f3edd436b9c7b30d8884328ce9ce671aa5"
+source = "git+https://github.com/Tubefeeder/tubefeeder-extractor.git?rev=a8470b66031ef85485e42ce5e649a0dad715adfb#a8470b66031ef85485e42ce5e649a0dad715adfb"
 dependencies = [
  "log",
  "tf_observer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,9 +25,10 @@ reqwest = "0.11.4"
 log = "0.4.14"
 env_logger = "0.9.0"
 
-tf_core = { package = "tf_core", git = "https://github.com/Tubefeeder/tubefeeder-extractor.git", rev = "f697eecb893f0761d89df9ce2763a87d6a0f01df" }
-tf_join = { package = "tf_join", git = "https://github.com/Tubefeeder/tubefeeder-extractor.git", rev = "f697eecb893f0761d89df9ce2763a87d6a0f01df" }
-tf_filter = { package = "tf_filter", git = "https://github.com/Tubefeeder/tubefeeder-extractor.git", rev = "f697eecb893f0761d89df9ce2763a87d6a0f01df" }
-tf_observer = { package = "tf_observer", git = "https://github.com/Tubefeeder/tubefeeder-extractor.git", rev = "f697eecb893f0761d89df9ce2763a87d6a0f01df" }
-tf_playlist = { package = "tf_playlist", git = "https://github.com/Tubefeeder/tubefeeder-extractor.git", rev = "f697eecb893f0761d89df9ce2763a87d6a0f01df" }
-tf_yt = { package = "tf_platform_youtube", git = "https://github.com/Tubefeeder/tubefeeder-extractor.git", rev = "f697eecb893f0761d89df9ce2763a87d6a0f01df" }
+tf_core = { package = "tf_core", git = "https://github.com/Tubefeeder/tubefeeder-extractor.git", branch = "platform-peertube" }
+tf_join = { package = "tf_join", git = "https://github.com/Tubefeeder/tubefeeder-extractor.git", branch = "platform-peertube" }
+tf_filter = { package = "tf_filter", git = "https://github.com/Tubefeeder/tubefeeder-extractor.git", branch = "platform-peertube" }
+tf_observer = { package = "tf_observer", git = "https://github.com/Tubefeeder/tubefeeder-extractor.git", branch = "platform-peertube" }
+tf_playlist = { package = "tf_playlist", git = "https://github.com/Tubefeeder/tubefeeder-extractor.git", branch = "platform-peertube" }
+tf_yt = { package = "tf_platform_youtube", git = "https://github.com/Tubefeeder/tubefeeder-extractor.git", branch = "platform-peertube" }
+tf_pt = { package = "tf_platform_peertube", git = "https://github.com/Tubefeeder/tubefeeder-extractor.git", branch = "platform-peertube" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,10 +25,10 @@ reqwest = "0.11.4"
 log = "0.4.14"
 env_logger = "0.9.0"
 
-tf_core = { package = "tf_core", git = "https://github.com/Tubefeeder/tubefeeder-extractor.git", branch = "platform-peertube" }
-tf_join = { package = "tf_join", git = "https://github.com/Tubefeeder/tubefeeder-extractor.git", branch = "platform-peertube" }
-tf_filter = { package = "tf_filter", git = "https://github.com/Tubefeeder/tubefeeder-extractor.git", branch = "platform-peertube" }
-tf_observer = { package = "tf_observer", git = "https://github.com/Tubefeeder/tubefeeder-extractor.git", branch = "platform-peertube" }
-tf_playlist = { package = "tf_playlist", git = "https://github.com/Tubefeeder/tubefeeder-extractor.git", branch = "platform-peertube" }
-tf_yt = { package = "tf_platform_youtube", git = "https://github.com/Tubefeeder/tubefeeder-extractor.git", branch = "platform-peertube" }
-tf_pt = { package = "tf_platform_peertube", git = "https://github.com/Tubefeeder/tubefeeder-extractor.git", branch = "platform-peertube" }
+tf_core = { package = "tf_core", git = "https://github.com/Tubefeeder/tubefeeder-extractor.git", rev = "a8470b66031ef85485e42ce5e649a0dad715adfb" }
+tf_join = { package = "tf_join", git = "https://github.com/Tubefeeder/tubefeeder-extractor.git", rev = "a8470b66031ef85485e42ce5e649a0dad715adfb" }
+tf_filter = { package = "tf_filter", git = "https://github.com/Tubefeeder/tubefeeder-extractor.git", rev = "a8470b66031ef85485e42ce5e649a0dad715adfb" }
+tf_observer = { package = "tf_observer", git = "https://github.com/Tubefeeder/tubefeeder-extractor.git", rev = "a8470b66031ef85485e42ce5e649a0dad715adfb" }
+tf_playlist = { package = "tf_playlist", git = "https://github.com/Tubefeeder/tubefeeder-extractor.git", rev = "a8470b66031ef85485e42ce5e649a0dad715adfb" }
+tf_yt = { package = "tf_platform_youtube", git = "https://github.com/Tubefeeder/tubefeeder-extractor.git", rev = "a8470b66031ef85485e42ce5e649a0dad715adfb" }
+tf_pt = { package = "tf_platform_peertube", git = "https://github.com/Tubefeeder/tubefeeder-extractor.git", rev = "a8470b66031ef85485e42ce5e649a0dad715adfb" }

--- a/src/gui/feed/feed_item.rs
+++ b/src/gui/feed/feed_item.rs
@@ -127,18 +127,20 @@ impl Widget for FeedListItem {
             .label_title
             .set_attributes(Some(&title_attr_list));
 
-        let author_attr_list = AttrList::new();
-        author_attr_list.insert(Attribute::new_size(
+        let small_text_attr_list = AttrList::new();
+        small_text_attr_list.insert(Attribute::new_size(
             (FONT_RATIO * (font_size * pango::SCALE) as f32) as i32,
         ));
+
         self.widgets
             .label_author
-            .set_attributes(Some(&author_attr_list));
-
-        let date_attr_list = author_attr_list;
+            .set_attributes(Some(&small_text_attr_list));
+        self.widgets
+            .label_platform
+            .set_attributes(Some(&small_text_attr_list));
         self.widgets
             .label_date
-            .set_attributes(Some(&date_attr_list));
+            .set_attributes(Some(&small_text_attr_list));
 
         self.widgets.playing.set_from_icon_name(
             Some("media-playback-start-symbolic"),
@@ -181,13 +183,24 @@ impl Widget for FeedListItem {
                         lines: 2,
                         justify: Justification::Left,
                     },
-                    #[name="label_author"]
-                    gtk::Label {
-                        text: &self.model.entry.subscription().to_string(),
-                        ellipsize: EllipsizeMode::End,
-                        wrap: true,
-                        wrap_mode: WrapMode::Word,
-                        halign: Align::Start
+                    gtk::Box {
+                        spacing: 4,
+                        #[name="label_author"]
+                        gtk::Label {
+                            text: &self.model.entry.subscription().to_string(),
+                            ellipsize: EllipsizeMode::End,
+                            wrap: true,
+                            wrap_mode: WrapMode::Word,
+                            halign: Align::Start
+                        },
+                        #[name="label_platform"]
+                        gtk::Label {
+                            text: &("(".to_owned() + &self.model.entry.platform().to_string() + ")"),
+                            ellipsize: EllipsizeMode::End,
+                            wrap: true,
+                            wrap_mode: WrapMode::Word,
+                            halign: Align::Start
+                        },
                     },
                     #[name="label_date"]
                     DateLabel(self.model.entry.uploaded().clone()) {}

--- a/src/gui/subscriptions/mod.rs
+++ b/src/gui/subscriptions/mod.rs
@@ -18,6 +18,7 @@
  *
  */
 
+mod subscription_adder;
 mod subscription_item;
 mod subscriptions_page;
 

--- a/src/gui/subscriptions/subscription_adder.rs
+++ b/src/gui/subscriptions/subscription_adder.rs
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2021 Julian Schmidhuber <github@schmiddi.anonaddy.com>
+ *
+ * This file is part of Tubefeeder.
+ *
+ * Tubefeeder is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Tubefeeder is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Tubefeeder.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+use std::str::FromStr;
+
+use gtk::prelude::*;
+use relm::{Relm, Widget};
+use relm_derive::{widget, Msg};
+use tf_join::{AnySubscription, AnySubscriptionList, Platform};
+use tf_pt::PTSubscription;
+use tf_yt::YTSubscription;
+
+#[derive(Msg)]
+pub enum SubscriptionAdderMsg {
+    ToggleVisible,
+    AddSubscription,
+    ChangePlatform(Platform),
+}
+
+pub struct SubscriptionAdderModel {
+    relm: Relm<SubscriptionAdder>,
+    visible: bool,
+    subscription_list: AnySubscriptionList,
+    platform: Platform,
+}
+
+#[widget]
+impl Widget for SubscriptionAdder {
+    fn model(relm: &Relm<Self>, subscription_list: AnySubscriptionList) -> SubscriptionAdderModel {
+        SubscriptionAdderModel {
+            relm: relm.clone(),
+            visible: false,
+            subscription_list,
+            platform: Platform::Youtube,
+        }
+    }
+
+    fn update(&mut self, event: SubscriptionAdderMsg) {
+        match event {
+            SubscriptionAdderMsg::ToggleVisible => {
+                self.model.visible = !self.model.visible;
+            }
+            SubscriptionAdderMsg::AddSubscription => self.add_subscription(),
+            SubscriptionAdderMsg::ChangePlatform(platform) => {
+                self.model.platform = platform;
+            }
+        }
+    }
+
+    fn add_subscription(&mut self) {
+        let channel_id_or_name = self.widgets.channel_id_or_name_entry.text();
+        let base_url = self.widgets.base_url_entry.text();
+
+        self.widgets.channel_id_or_name_entry.set_text("");
+        self.widgets.base_url_entry.set_text("");
+
+        self.model
+            .relm
+            .stream()
+            .emit(SubscriptionAdderMsg::ToggleVisible);
+
+        let sub_list = self.model.subscription_list.clone();
+        let platform = self.model.platform.clone();
+
+        std::thread::spawn(move || {
+            // TODO: Differentiate between platforms.
+            let sub_res: Result<AnySubscription, tf_core::Error> =
+                tokio::runtime::Runtime::new().unwrap().block_on(async {
+                    match platform {
+                        Platform::Youtube => YTSubscription::from_id_or_name(&channel_id_or_name)
+                            .await
+                            .map(|s| s.into()),
+                        Platform::Peertube => {
+                            Ok(PTSubscription::new(&base_url, &channel_id_or_name).into())
+                        }
+                    }
+                });
+
+            // TODO: Error handling
+            if let Ok(sub) = sub_res {
+                sub_list.add(sub);
+            }
+        });
+    }
+
+    fn init_view(&mut self) {
+        let platform_combobox = gtk::ComboBoxText::new();
+
+        for value in Platform::values() {
+            let item = value.to_string();
+            platform_combobox.append(Some(&item), &item);
+        }
+        platform_combobox.set_active(Some(0));
+
+        let platform_combobox_clone = platform_combobox.clone();
+
+        relm::connect!(
+            self.model.relm,
+            platform_combobox.clone(),
+            connect_changed(_),
+            SubscriptionAdderMsg::ChangePlatform(Platform::from(
+                Platform::from_str(
+                    &platform_combobox_clone
+                        .active_id()
+                        .unwrap_or(glib::GString::from("")),
+                )
+                .unwrap_or(Platform::Youtube),
+            ))
+        );
+
+        self.widgets
+            .platform_combobox_holder
+            .add(&platform_combobox);
+        self.widgets.platform_combobox_holder.show_all();
+    }
+
+    view! {
+        #[name="channel_entry_box"]
+        gtk::Box {
+            visible: self.model.visible,
+            #[name="platform_combobox_holder"]
+            gtk::Box {
+
+            },
+
+            #[name="base_url_entry"]
+            gtk::Entry {
+                placeholder_text: Some("Base URL"),
+                visible: self.model.platform == Platform::Peertube
+            },
+            #[name="channel_id_or_name_entry"]
+            gtk::Entry {
+                placeholder_text: Some("Channel ID or Name")
+            },
+            gtk::Button {
+                clicked => SubscriptionAdderMsg::AddSubscription,
+                image: Some(&gtk::Image::from_icon_name(Some("go-next-symbolic"), gtk::IconSize::LargeToolbar)),
+            }
+        },
+    }
+}

--- a/src/gui/subscriptions/subscription_item.rs
+++ b/src/gui/subscriptions/subscription_item.rs
@@ -22,7 +22,6 @@ use crate::gui::get_font_size;
 
 use gtk::prelude::*;
 use gtk::Align;
-use gtk::Orientation::Vertical;
 use pango::{AttrList, Attribute, EllipsizeMode};
 use relm::{Relm, Widget};
 use relm_derive::{widget, Msg};
@@ -115,11 +114,18 @@ impl Widget for SubscriptionItem {
                     clicked => SubscriptionItemMsg::Remove,
                 },
                 gtk::Box {
-                    orientation: Vertical,
+                    spacing: 4,
                     #[name="label_name"]
                     gtk::Label {
                         text: &self.model.subscription.to_string(),
                         ellipsize: EllipsizeMode::End,
+                        halign: Align::Start
+                    },
+                    #[name="label_platform"]
+                    gtk::Label {
+                        text: &("(".to_owned() + &self.model.subscription.platform().to_string() + ")"),
+                        ellipsize: EllipsizeMode::End,
+                        wrap: true,
                         halign: Align::Start
                     },
                 }

--- a/src/player.rs
+++ b/src/player.rs
@@ -28,8 +28,9 @@ use tf_join::AnyVideo;
 pub fn play(video: AnyVideo) {
     thread::spawn(move || {
         log::debug!("Playing video with title: {}", video.title());
+        log::debug!("Playing video with url: {}", video.url());
         video.play();
-        let player_str = std::env::var("PLAYER").unwrap_or("mpv".to_string());
+        let player_str = std::env::var("PLAYER").unwrap_or("mpv --ytdl".to_string());
 
         let mut player_iter = player_str.split(" ");
         let player = player_iter.next().unwrap_or("mpv");


### PR DESCRIPTION
# Licensing 

- [x] I confirm that this is either my code or was released under the terms of a GPLv3-or-later compatible license. Also I agree to release it here under the terms of the GPLv3-or-later.

# Description

This will add basic peertube support.

Note: The subscription id is the same when directly copying the id from peertube.
Note: MPV does currently not support peertube (see [here](https://github.com/ytdl-org/youtube-dl/issues/29782)).

# Linked Issue

Closes #18.

# TODO

- [x] Indicate on video and subscription where it originated (youtube, peertube, etc)
- [x] Add documentatio to the wiki
- [ ] ~~Update images~~ (Moved to after the lbry support)