### PR TITLE
Adaptive Title/Bar ViewSwitcher

### DIFF
--- a/src/gui/window.rs
+++ b/src/gui/window.rs
@@ -34,8 +34,6 @@ gtk::glib::wrapper! {
 
 impl Window {
     pub fn new(app: &gtk::Application) -> Self {
-        // Make sure HeaderBar is loaded.
-        let _ = super::header_bar::HeaderBar::new();
         Object::new(&[("application", app)]).expect("Failed to create Window")
     }
 
@@ -82,7 +80,10 @@ pub mod imp {
     #[template(resource = "/ui/window.ui")]
     pub struct Window {
         #[template_child]
-        application_stack: TemplateChild<libadwaita::ViewStack>,
+        pub(in crate::gui) application_stack: TemplateChild<libadwaita::ViewStack>,
+
+        #[template_child]
+        pub(in crate::gui) application_stack_bar: TemplateChild<libadwaita::ViewSwitcherBar>,
 
         #[template_child]
         pub(super) feed_page: TemplateChild<FeedPage>,
@@ -225,6 +226,8 @@ pub mod imp {
         type ParentType = libadwaita::ApplicationWindow;
 
         fn class_init(klass: &mut Self::Class) {
+            // Make sure HeaderBar is loaded.
+            crate::gui::header_bar::HeaderBar::ensure_type();
             Self::bind_template(klass);
         }
 

--- a/ui/header_bar.ui
+++ b/ui/header_bar.ui
@@ -14,13 +14,17 @@
         <property name="vexpand">True</property>
         <property name="halign">GTK_ALIGN_FILL</property>
         <property name="valign">GTK_ALIGN_FILL</property>
-        <property name="title-widget">
-          <object class="AdwWindowTitle">
-            <binding name="title">
-              <lookup name="title" type="TFHeaderBar"/>
-            </binding>
+        <child type="title">
+          <object class="GtkBox">
+            <child>
+              <object class="AdwViewSwitcherTitle" id="titlebar">
+                <binding name="title">
+                  <lookup name="title" type="TFHeaderBar"/>
+                </binding>
+              </object>
+            </child>
           </object>
-        </property>
+        </child>
 
         <child>
           <object class="GtkBox" id="child_box">

--- a/ui/window.ui
+++ b/ui/window.ui
@@ -55,7 +55,7 @@
         </child>
 
         <child>
-          <object class = "AdwViewSwitcher">
+          <object class="AdwViewSwitcherBar" id="application_stack_bar">
               <property name="hexpand">True</property>
               <property name="vexpand">False</property>
               <property name="halign">GTK_ALIGN_FILL</property>


### PR DESCRIPTION
# Licensing 

- [x] I confirm that this is either my code or was released under the terms of a GPLv3-or-later compatible license. Also I agree to release it here under the terms of the GPLv3-or-later.

# Description

This adds a view switcher in the title bar that is shown if the window
is big enough, additionally, the bar at the bottom will be hidden at big
width.

If the window is small, the title bar will not be shown, instead the
bottom bar is visible.

# Linked Issue

Closes #62