### PR TITLE
Play local videos

### DIFF
--- a/ui/feed_item.ui
+++ b/ui/feed_item.ui
@@ -117,6 +117,18 @@
             <property name="halign">GTK_ALIGN_START</property>
           </object>
         </child>
+        <child>
+          <object class="GtkImage" id="is-local">
+            <property name="halign">GTK_ALIGN_START</property>
+            <property name="icon-name">folder-download-symbolic</property>
+            <binding name="visible">
+              <lookup name="is-local">
+                <lookup name="video" type="TFFeedItem">
+                </lookup>
+              </lookup>
+            </binding>
+          </object>
+        </child>
       </object>
     </child>
     <child>


### PR DESCRIPTION
# Licensing 

- [x] I confirm that this is either my code or was released under the terms of a GPLv3-or-later compatible license. Also I agree to release it here under the terms of the GPLv3-or-later.

# Description

After downloading videos, a small icon will be visible indicating that the video is available locally. If the video is available locally, playing it will result in playing the local file instead of playing the web-version.

Note that this will currently only work with `youtube-dl` and most of its derivatives. Also note that restarting the application will reset the association with the local video, the downloaded video will have to be deleted and redownloaded again.

# Linked Issue

Closes #72.
