### PR TITLE
Add initial settings

### DIFF
--- a/data/de.schmidhuberj.tubefeeder.gschema.xml
+++ b/data/de.schmidhuberj.tubefeeder.gschema.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<schemalist>
+  <schema path="/de/schmidhuberj/tubefeeder/" id="de.schmidhuberj.tubefeeder" gettext-domain="tubefeeder">
+    <key name="window-width" type="i">
+      <default>500</default>
+      <summary>Window width</summary>
+    </key>
+    <key name="window-height" type="i">
+      <default>800</default>
+      <summary>Window height</summary>
+    </key>
+    <key name="is-maximized" type="b">
+      <default>false</default>
+      <summary>Window maximized state</summary>
+    </key>
+
+    <key name="player" type="s">
+      <default>"mpv"</default>
+      <summary>The player to use</summary>
+    </key>
+    <key name="downloader" type="s">
+      <default>"youtube-dl"</default>
+      <summary>The downloader to use</summary>
+    </key>
+    <key name="piped-url" type="s">
+      <default>"https://pipedapi.kavin.rocks"</default>
+      <summary>The piped api url</summary>
+    </key>
+  </schema>
+</schemalist>

--- a/data/de.schmidhuberj.tubefeeder.metainfo.xml
+++ b/data/de.schmidhuberj.tubefeeder.metainfo.xml
@@ -124,19 +124,19 @@
   <screenshots>
     <screenshot type="default">
       <caption>The feed</caption>
-      <image>https://github.com/Schmiddiii/Tubefeeder/blob/master/screenshots/tubefeeder_screenshot_feed.png?raw=true</image>
+      <image>https://github.com/Schmiddiii/Tubefeeder/blob/master/data/screenshots/tubefeeder_screenshot_feed.png?raw=true</image>
     </screenshot>
     <screenshot type="default">
       <caption>The watch later list</caption>
-      <image>https://github.com/Schmiddiii/Tubefeeder/blob/master/screenshots/tubefeeder_screenshot_watch_later.png?raw=true</image>
+      <image>https://github.com/Schmiddiii/Tubefeeder/blob/master/data/screenshots/tubefeeder_screenshot_watch_later.png?raw=true</image>
     </screenshot>
     <screenshot type="default">
       <caption>The filter</caption>
-      <image>https://github.com/Schmiddiii/Tubefeeder/blob/master/screenshots/tubefeeder_screenshot_filters.png?raw=true</image>
+      <image>https://github.com/Schmiddiii/Tubefeeder/blob/master/data/screenshots/tubefeeder_screenshot_filters.png?raw=true</image>
     </screenshot>
     <screenshot>
       <caption>The subscriptions</caption>
-      <image>https://github.com/Schmiddiii/Tubefeeder/blob/master/screenshots/tubefeeder_screenshot_subscriptions.png?raw=true</image>
+      <image>https://github.com/Schmiddiii/Tubefeeder/blob/master/data/screenshots/tubefeeder_screenshot_subscriptions.png?raw=true</image>
     </screenshot>
   </screenshots>
 

--- a/data/meson.build
+++ b/data/meson.build
@@ -12,3 +12,8 @@ install_data(
   '@0@.metainfo.xml'.format(application_id),
   install_dir: datadir / 'metainfo'
 )
+
+install_data(
+  '@0@.gschema.xml'.format(application_id),
+  install_dir: datadir / 'glib-2.0' / 'schemas'
+)

--- a/data/resources/resources.gresource.xml
+++ b/data/resources/resources.gresource.xml
@@ -15,6 +15,7 @@
     <file preprocess="xml-stripblanks">ui/subscription_page.ui</file>
     <file preprocess="xml-stripblanks">ui/thumbnail.ui</file>
     <file preprocess="xml-stripblanks">ui/watch_later.ui</file>
+    <file preprocess="xml-stripblanks">ui/preferences_window.ui</file>
   </gresource>
   <gresource prefix="/de/schmidhuberj/tubefeeder/icons/">
     <file alias="icon.svg">../icons/de.schmidhuberj.tubefeeder.svg</file>

--- a/data/resources/ui/header_bar.ui
+++ b/data/resources/ui/header_bar.ui
@@ -41,6 +41,10 @@
   <menu id="menubar">
     <section>
       <item>
+        <attribute name="label" translatable="yes">Settings</attribute>
+        <attribute name="action">win.settings</attribute>
+      </item>
+      <item>
         <attribute name="label" translatable="yes">About</attribute>
         <attribute name="action">win.about</attribute>
       </item>

--- a/data/resources/ui/preferences_window.ui
+++ b/data/resources/ui/preferences_window.ui
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <requires lib="gtk+" version="3.24"/>
+  <requires lib="libadwaita" version="1.0"/>
+
+  <template class="TFPreferencesWindow" parent="AdwPreferencesWindow">
+    <child>
+      <object class="AdwPreferencesPage">
+        <property name="title" translatable="yes">General</property>
+        <property name="icon-name">preferences-system-symbolic</property>
+        <child>
+          <object class="AdwPreferencesGroup" id="group_programs">
+            <property name="title" translatable="yes">Programs</property>
+            <child>
+              <object class="AdwActionRow">
+                <property name="title" translatable="yes">Player</property>
+                <child>
+                  <object class="GtkEntry" id="entry_player">
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="AdwActionRow">
+                <property name="title" translatable="yes">Downloader</property>
+                <child>
+                  <object class="GtkEntry" id="entry_downloader">
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="AdwPreferencesGroup">
+            <property name="title" translatable="yes">APIs</property>
+            <property name="description" translatable="yes">For a list of public APIs, see https://github.com/TeamPiped/Piped/wiki/Instances.</property>
+            <child>
+              <object class="AdwActionRow">
+                <property name="title" translatable="yes">Piped API</property>
+                <child>
+                  <object class="GtkEntry" id="entry_piped_api">
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+  </template>
+</interface>

--- a/data/resources/ui/window.ui
+++ b/data/resources/ui/window.ui
@@ -63,7 +63,6 @@
               <property name="stack">application_stack</property>
           </object>
         </child>
-
       </object>
     </child>
   </template>

--- a/meson.build
+++ b/meson.build
@@ -47,6 +47,7 @@ else
   version_suffix = ''
   application_id = base_id
 endif
+flatpak = get_option('flatpak')
 
 meson.add_dist_script(
   'build-aux/dist-vendor.sh',
@@ -60,6 +61,6 @@ subdir('src')
 
 gnome.post_install(
   gtk_update_icon_cache: true,
-  glib_compile_schemas: false,
+  glib_compile_schemas: true,
   update_desktop_database: true,
 )

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -8,3 +8,14 @@ option(
   value: 'default',
   description: 'The build profile for Tubefeeder. One of "default" or "development".'
 )
+
+option(
+  'flatpak',
+  type: 'combo',
+  choices: [
+    'true',
+    'false',
+  ],
+  value: 'false',
+  description: 'Is the build a flatpak build. One of "true" or "false".'
+)

--- a/src/config.rs.in
+++ b/src/config.rs.in
@@ -1,6 +1,7 @@
 pub const APP_ID: &str = @APP_ID@;
 pub const GETTEXT_PACKAGE: &str = @GETTEXT_PACKAGE@;
 pub const LOCALEDIR: &str = @LOCALEDIR@;
-// pub const PROFILE: &str = @PROFILE@;
+pub const PROFILE: &str = @PROFILE@;
 // pub const VERSION: &str = @VERSION@;
+pub const FLATPAK: bool = @FLATPAK@;
 pub const RESOURCES_BYTES: &[u8] = include_bytes!(concat!(@BUILD_DIR@, "/data/resources/resources.gresource"));

--- a/src/gui/header_bar.rs
+++ b/src/gui/header_bar.rs
@@ -55,6 +55,8 @@ pub mod imp {
     use gtk::CompositeTemplate;
     use once_cell::sync::Lazy;
 
+    use crate::gui::preferences_window::PreferencesWindow;
+
     #[derive(CompositeTemplate, Default)]
     #[template(resource = "/ui/header_bar.ui")]
     pub struct HeaderBar {
@@ -69,6 +71,12 @@ pub mod imp {
 
     impl HeaderBar {
         fn setup_actions(&self, obj: &super::HeaderBar) {
+            let action_settings = SimpleAction::new("settings", None);
+            action_settings.connect_activate(|_, _| {
+                let settings = PreferencesWindow::new();
+                settings.show();
+            });
+
             let action_about = SimpleAction::new("about", None);
             action_about.connect_activate(|_, _| {
                 let about_dialog = AboutDialogBuilder::new()
@@ -98,6 +106,7 @@ pub mod imp {
             let actions = SimpleActionGroup::new();
             obj.insert_action_group("win", Some(&actions));
             actions.add_action(&action_about);
+            actions.add_action(&action_settings);
         }
     }
 

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -21,6 +21,7 @@
 mod feed;
 mod filter;
 mod header_bar;
+mod preferences_window;
 mod subscription;
 mod utility;
 mod watch_later;

--- a/src/gui/preferences_window.rs
+++ b/src/gui/preferences_window.rs
@@ -1,0 +1,130 @@
+use gdk::glib::Object;
+
+gtk::glib::wrapper! {
+    pub struct PreferencesWindow(ObjectSubclass<imp::PreferencesWindow>)
+        @extends libadwaita::PreferencesWindow, libadwaita::Window, gtk::Window, gtk::Widget,
+        @implements gtk::gio::ActionGroup, gtk::gio::ActionMap, gtk::Accessible, gtk::Buildable,
+            gtk::ConstraintTarget, gtk::Native, gtk::Root, gtk::ShortcutManager;
+}
+
+impl PreferencesWindow {
+    pub fn new() -> Self {
+        Object::new(&[]).expect("Failed to create PreferencesWindow")
+    }
+}
+
+pub mod imp {
+    use gdk::gio::Settings;
+    use gdk::gio::SettingsBindFlags;
+    use glib::subclass::InitializingObject;
+    use gtk::glib;
+    use gtk::prelude::*;
+    use gtk::subclass::prelude::*;
+    use gtk::CompositeTemplate;
+    use libadwaita::subclass::prelude::AdwWindowImpl;
+    use libadwaita::subclass::prelude::PreferencesWindowImpl;
+    use libadwaita::traits::ActionRowExt;
+    use libadwaita::traits::PreferencesGroupExt;
+
+    #[derive(CompositeTemplate)]
+    #[template(resource = "/ui/preferences_window.ui")]
+    pub struct PreferencesWindow {
+        #[template_child]
+        entry_player: TemplateChild<gtk::Entry>,
+        #[template_child]
+        entry_downloader: TemplateChild<gtk::Entry>,
+
+        #[template_child]
+        entry_piped_api: TemplateChild<gtk::Entry>,
+
+        #[template_child]
+        group_programs: TemplateChild<libadwaita::PreferencesGroup>,
+
+        settings: Settings,
+    }
+
+    #[gtk::template_callbacks]
+    impl PreferencesWindow {
+        fn init_flatpak(&self) {
+            self.group_programs.set_description(Some(&gettextrs::gettext("Note that on Flatpak, there are some more steps required when using a player external to the Flatpak. For more information, please consult the wiki.")));
+        }
+
+        fn init_string_setting(
+            &self,
+            env: &'static str,
+            settings: &'static str,
+            entry: gtk::Entry,
+        ) {
+            let val_env = std::env::var_os(env);
+            let val_settings = self.settings.string(settings);
+            entry.set_text(&val_settings);
+            if val_env.is_some() && &val_env.unwrap() != val_settings.as_str() {
+                entry.set_editable(false);
+                // TODO: Not really nice to access the parents.
+                entry
+                    .parent()
+                    .expect("Settings entry to have parent")
+                    .parent()
+                    .expect("Settings entry to have parent")
+                    .parent()
+                    .expect("Settings entry to have parent")
+                    .dynamic_cast::<libadwaita::ActionRow>()
+                    .expect("Settings entry to have parent of thpe ActionRow")
+                    .set_subtitle(&gettextrs::gettext(
+                        "Overwritten by environmental variable.",
+                    ));
+            }
+            self.settings
+                .bind(settings, &entry, "text")
+                .flags(SettingsBindFlags::DEFAULT)
+                .build();
+            entry.connect_changed(move |entry| std::env::set_var(env, entry.text()));
+        }
+
+        fn init_settings(&self) {
+            self.init_string_setting("PLAYER", "player", self.entry_player.get());
+            self.init_string_setting("DOWNLOADER", "downloader", self.entry_downloader.get());
+            self.init_string_setting("PIPED_API_URL", "piped-url", self.entry_piped_api.get());
+        }
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for PreferencesWindow {
+        const NAME: &'static str = "TFPreferencesWindow";
+        type Type = super::PreferencesWindow;
+        type ParentType = libadwaita::PreferencesWindow;
+
+        fn new() -> Self {
+            Self {
+                settings: Settings::new(crate::config::APP_ID),
+                group_programs: TemplateChild::default(),
+                entry_player: TemplateChild::default(),
+                entry_downloader: TemplateChild::default(),
+                entry_piped_api: TemplateChild::default(),
+            }
+        }
+
+        fn class_init(klass: &mut Self::Class) {
+            Self::bind_template(klass);
+            Self::bind_template_callbacks(klass);
+        }
+
+        fn instance_init(obj: &InitializingObject<Self>) {
+            obj.init_template();
+        }
+    }
+
+    impl ObjectImpl for PreferencesWindow {
+        fn constructed(&self, obj: &Self::Type) {
+            self.parent_constructed(obj);
+            self.init_settings();
+            if crate::config::FLATPAK {
+                self.init_flatpak();
+            }
+        }
+    }
+    impl WidgetImpl for PreferencesWindow {}
+    impl WindowImpl for PreferencesWindow {}
+    impl PreferencesWindowImpl for PreferencesWindow {}
+    impl AdwWindowImpl for PreferencesWindow {}
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@
  */
 
 use gdk::prelude::{ApplicationExt, ApplicationExtManual};
+use gdk_pixbuf::{gio::Settings, prelude::SettingsExt};
 use gtk::traits::GtkWindowExt;
 
 mod config;
@@ -28,6 +29,19 @@ mod csv_file_manager;
 mod downloader;
 mod gui;
 mod player;
+
+fn init_setting(env: &'static str, value: &str) {
+    if std::env::var_os(env).is_none() {
+        std::env::set_var(env, value);
+    }
+}
+
+fn init_settings() {
+    let settings = Settings::new(APP_ID);
+    init_setting("PLAYER", &settings.string("player"));
+    init_setting("DOWNLOADER", &settings.string("downloader"));
+    init_setting("PIPED_API_URL", &settings.string("piped-url"));
+}
 
 fn init_resources() {
     let gbytes = gtk::glib::Bytes::from_static(RESOURCES_BYTES);
@@ -66,9 +80,7 @@ async fn main() {
 
     gtk::init().expect("Failed to initialize gtk");
     libadwaita::init();
-    let app = gtk::Application::builder()
-        .application_id(APP_ID)
-        .build();
+    let app = gtk::Application::builder().application_id(APP_ID).build();
 
     app.connect_activate(build_ui);
     app.run();
@@ -77,6 +89,7 @@ async fn main() {
 fn build_ui(app: &gtk::Application) {
     init_resources();
     init_folders();
+    init_settings();
     // Create new window and present it
     let window = crate::gui::window::Window::new(app);
     window.present();

--- a/src/meson.build
+++ b/src/meson.build
@@ -6,6 +6,7 @@ global_conf.set_quoted('VERSION', version + version_suffix)
 global_conf.set_quoted('GETTEXT_PACKAGE', gettext_package)
 global_conf.set_quoted('LOCALEDIR', localedir)
 global_conf.set_quoted('BUILD_DIR', meson.project_build_root())
+global_conf.set('FLATPAK', flatpak)
 config = configure_file(
   input: 'config.rs.in',
   output: 'config.rs',


### PR DESCRIPTION
# Licensing 

- [x] I confirm that this is either my code or was released under the terms of a GPLv3-or-later compatible license. Also I agree to release it here under the terms of the GPLv3-or-later.

# Description

This adds support for settings instead of env-variables. The env-variables can still be used and will override the settings from GTK.