### PR TITLE
Import subscriptions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2275,6 +2275,8 @@ dependencies = [
  "pango",
  "regex",
  "reqwest",
+ "serde",
+ "serde_json",
  "tf_core",
  "tf_filter",
  "tf_join",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,9 @@ once_cell = "1.10.0"
 
 gettext-rs = "0.7.0"
 
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+
 tf_core = "0.1.2"
 tf_join = "0.1.4"
 tf_filter = "0.1.2"

--- a/data/resources/resources.gresource.xml
+++ b/data/resources/resources.gresource.xml
@@ -16,6 +16,7 @@
     <file preprocess="xml-stripblanks">ui/thumbnail.ui</file>
     <file preprocess="xml-stripblanks">ui/watch_later.ui</file>
     <file preprocess="xml-stripblanks">ui/preferences_window.ui</file>
+    <file preprocess="xml-stripblanks">ui/import_window.ui</file>
   </gresource>
   <gresource prefix="/de/schmidhuberj/tubefeeder/icons/">
     <file alias="icon.svg">../icons/de.schmidhuberj.tubefeeder.svg</file>

--- a/data/resources/ui/feed_page.ui
+++ b/data/resources/ui/feed_page.ui
@@ -19,6 +19,9 @@
               <object class="GtkBox" id="box_refresh">
                 <child>
                   <object class="GtkButton" id="btn_reload">
+                    <style>
+                      <class name="flat"/>
+                    </style>
                     <binding name="visible">
                       <closure function="not" type="gboolean">
                         <lookup name="reloading" type="TFFeedPage"></lookup>

--- a/data/resources/ui/filter_page.ui
+++ b/data/resources/ui/filter_page.ui
@@ -17,6 +17,9 @@
 
             <property name="child">
               <object class="GtkButton" id="btn_toggle_add_filter">
+                <style>
+                  <class name="flat"/>
+                </style>
                 <property name="visible">True</property>
                 <child>
                   <object class="GtkImage">

--- a/data/resources/ui/header_bar.ui
+++ b/data/resources/ui/header_bar.ui
@@ -45,6 +45,10 @@
         <attribute name="action">win.settings</attribute>
       </item>
       <item>
+        <attribute name="label" translatable="yes">Import</attribute>
+        <attribute name="action">win.import</attribute>
+      </item>
+      <item>
         <attribute name="label" translatable="yes">About</attribute>
         <attribute name="action">win.about</attribute>
       </item>

--- a/data/resources/ui/import_window.ui
+++ b/data/resources/ui/import_window.ui
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <requires lib="gtk+" version="3.24"/>
+  <requires lib="libadwaita" version="1.0"/>
+
+  <template class="TFImportWindow" parent="GtkDialog">
+    <property name="can-focus">True</property>
+    <property name="title" translatable="yes">Import</property>
+    <property name="default-height">100</property>
+    <property name="default-width">400</property>
+    <property name="destroy-with-parent">True</property>
+
+    <child internal-child="content_area">
+      <object class="GtkBox">
+        <child>
+          <object class="GtkLabel">
+            <property name="label" translatable="yes">This will import your subscriptions from exported data from NewPipe or Youtube.</property>
+
+            <property name="wrap">True</property>
+            <property name="xalign">0</property>
+            <property name="wrap-mode">word</property>
+            <property name="justify">left</property>
+            <property name="vexpand">False</property>
+            <property name="valign">start</property>
+            <property name="hexpand">True</property>
+            <property name="halign">start</property>
+          </object>
+        </child>
+      </object>
+    </child>
+
+    <child type="action">
+      <object class="GtkButton" id="button_newpipe">
+        <property name="label">NewPipe</property>
+      </object>
+    </child>
+    <child type="action">
+      <object class="GtkButton" id="button_youtube">
+        <property name="label">YouTube</property>
+      </object>
+    </child>
+    <child type="action">
+      <object class="GtkButton" id="button_cancel">
+        <property name="label" translatable="yes">Cancel</property>
+      </object>
+    </child>
+
+    <action-widgets>
+      <action-widget response="1">button_newpipe</action-widget>
+      <action-widget response="2">button_youtube</action-widget>
+      <action-widget response="cancel">button_cancel</action-widget>
+    </action-widgets>
+  </template>
+</interface>

--- a/data/resources/ui/subscription_page.ui
+++ b/data/resources/ui/subscription_page.ui
@@ -22,6 +22,9 @@
 
                     <property name="child">
                       <object class="GtkButton" id="btn_toggle_add_subscription">
+                        <style>
+                          <class name="flat"/>
+                        </style>
                         <property name="visible">True</property>
                         <child>
                           <object class="GtkImage">

--- a/po/POTFILES
+++ b/po/POTFILES
@@ -1,3 +1,6 @@
+# fd -t f -e ui . data/
+# fd -t f -e rs . src/
+
 data/resources/ui/error_label.ui
 data/resources/ui/feed_item.ui
 data/resources/ui/feed_list.ui
@@ -6,6 +9,8 @@ data/resources/ui/filter_item.ui
 data/resources/ui/filter_list.ui
 data/resources/ui/filter_page.ui
 data/resources/ui/header_bar.ui
+data/resources/ui/import_window.ui
+data/resources/ui/preferences_window.ui
 data/resources/ui/subscription_item.ui
 data/resources/ui/subscription_list.ui
 data/resources/ui/subscription_page.ui
@@ -13,6 +18,7 @@ data/resources/ui/thumbnail.ui
 data/resources/ui/watch_later.ui
 data/resources/ui/window.ui
 
+src/config.rs
 src/csv_file_manager.rs
 src/downloader.rs
 src/gui/feed/error_label.rs
@@ -28,7 +34,9 @@ src/gui/filter/filter_list.rs
 src/gui/filter/filter_page.rs
 src/gui/filter/mod.rs
 src/gui/header_bar.rs
+src/gui/import_window.rs
 src/gui/mod.rs
+src/gui/preferences_window.rs
 src/gui/subscription/mod.rs
 src/gui/subscription/platform.rs
 src/gui/subscription/subscription_item.rs
@@ -38,5 +46,6 @@ src/gui/subscription/subscription_page.rs
 src/gui/utility.rs
 src/gui/watch_later.rs
 src/gui/window.rs
+src/import.rs
 src/main.rs
 src/player.rs

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.5.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-08-05 17:15+0200\n"
+"POT-Creation-Date: 2022-08-08 12:47+0200\n"
 "PO-Revision-Date: 2022-07-17 22:20+0100\n"
 "Last-Translator: vikdevelop <super-vik1@protonmail.com>\n"
 "Language-Team: CZECH\n"
@@ -37,11 +37,11 @@ msgstr "Feed"
 msgid "Filters"
 msgstr "Filtry"
 
-#: data/resources/ui/filter_page.ui:40
+#: data/resources/ui/filter_page.ui:43
 msgid "Title"
 msgstr "Titulek"
 
-#: data/resources/ui/filter_page.ui:45
+#: data/resources/ui/filter_page.ui:48
 msgid "Channel Name"
 msgstr "Název kanálu"
 
@@ -80,9 +80,8 @@ msgid "Player"
 msgstr ""
 
 #: data/resources/ui/preferences_window.ui:25
-#, fuzzy
 msgid "Downloader"
-msgstr "Stáhnout"
+msgstr ""
 
 #: data/resources/ui/preferences_window.ui:36
 msgid "APIs"
@@ -99,15 +98,15 @@ msgid "Piped API"
 msgstr ""
 
 #: data/resources/ui/subscription_page.ui:21
-#: data/resources/ui/subscription_page.ui:95 data/resources/ui/window.ui:47
+#: data/resources/ui/subscription_page.ui:98 data/resources/ui/window.ui:47
 msgid "Subscriptions"
 msgstr "Odběry"
 
-#: data/resources/ui/subscription_page.ui:56
+#: data/resources/ui/subscription_page.ui:59
 msgid "Base URL"
 msgstr "Základní adresa URL"
 
-#: data/resources/ui/subscription_page.ui:68
+#: data/resources/ui/subscription_page.ui:71
 msgid "Channel ID or Name"
 msgstr "ID nebo název kanálu"
 
@@ -132,6 +131,10 @@ msgstr "Došlo k nějaké chybě"
 #: src/gui/feed/feed_item_object.rs:88
 msgid "%F %T"
 msgstr "%F %T"
+
+#: src/gui/import_window.rs:83 src/gui/import_window.rs:114
+msgid "Failure to import subscriptions"
+msgstr ""
 
 #: src/gui/preferences_window.rs:49
 msgid ""

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.5.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-08-01 17:19+0200\n"
+"POT-Creation-Date: 2022-08-05 17:15+0200\n"
 "PO-Revision-Date: 2022-07-17 22:20+0100\n"
 "Last-Translator: vikdevelop <super-vik1@protonmail.com>\n"
 "Language-Team: CZECH\n"
@@ -46,8 +46,57 @@ msgid "Channel Name"
 msgstr "Název kanálu"
 
 #: data/resources/ui/header_bar.ui:44
+msgid "Settings"
+msgstr ""
+
+#: data/resources/ui/header_bar.ui:48 data/resources/ui/import_window.ui:8
+msgid "Import"
+msgstr ""
+
+#: data/resources/ui/header_bar.ui:52
 msgid "About"
 msgstr "O programu"
+
+#: data/resources/ui/import_window.ui:17
+msgid ""
+"This will import your subscriptions from exported data from NewPipe or "
+"Youtube."
+msgstr ""
+
+#: data/resources/ui/import_window.ui:44
+msgid "Cancel"
+msgstr ""
+
+#: data/resources/ui/preferences_window.ui:9
+msgid "General"
+msgstr ""
+
+#: data/resources/ui/preferences_window.ui:13
+msgid "Programs"
+msgstr ""
+
+#: data/resources/ui/preferences_window.ui:16
+msgid "Player"
+msgstr ""
+
+#: data/resources/ui/preferences_window.ui:25
+#, fuzzy
+msgid "Downloader"
+msgstr "Stáhnout"
+
+#: data/resources/ui/preferences_window.ui:36
+msgid "APIs"
+msgstr ""
+
+#: data/resources/ui/preferences_window.ui:37
+msgid ""
+"For a list of public APIs, see https://github.com/TeamPiped/Piped/wiki/"
+"Instances."
+msgstr ""
+
+#: data/resources/ui/preferences_window.ui:40
+msgid "Piped API"
+msgstr ""
 
 #: data/resources/ui/subscription_page.ui:21
 #: data/resources/ui/subscription_page.ui:95 data/resources/ui/window.ui:47
@@ -83,3 +132,13 @@ msgstr "Došlo k nějaké chybě"
 #: src/gui/feed/feed_item_object.rs:88
 msgid "%F %T"
 msgstr "%F %T"
+
+#: src/gui/preferences_window.rs:49
+msgid ""
+"Note that on Flatpak, there are some more steps required when using a player "
+"external to the Flatpak. For more information, please consult the wiki."
+msgstr ""
+
+#: src/gui/preferences_window.rs:74
+msgid "Overwritten by environmental variable."
+msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.5.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-08-05 17:15+0200\n"
+"POT-Creation-Date: 2022-08-08 12:47+0200\n"
 "PO-Revision-Date: 2022-03-05 15:52+0100\n"
 "Last-Translator: Julian Schmidhuber <internationalization@schmiddi.anonaddy."
 "com>\n"
@@ -38,21 +38,21 @@ msgstr "Feed"
 msgid "Filters"
 msgstr "Filter"
 
-#: data/resources/ui/filter_page.ui:40
+#: data/resources/ui/filter_page.ui:43
 msgid "Title"
 msgstr "Titel"
 
-#: data/resources/ui/filter_page.ui:45
+#: data/resources/ui/filter_page.ui:48
 msgid "Channel Name"
 msgstr "Kanal-Name"
 
 #: data/resources/ui/header_bar.ui:44
 msgid "Settings"
-msgstr ""
+msgstr "Einstellungen"
 
 #: data/resources/ui/header_bar.ui:48 data/resources/ui/import_window.ui:8
 msgid "Import"
-msgstr ""
+msgstr "Importieren"
 
 #: data/resources/ui/header_bar.ui:52
 msgid "About"
@@ -62,53 +62,52 @@ msgstr "Über"
 msgid ""
 "This will import your subscriptions from exported data from NewPipe or "
 "Youtube."
-msgstr ""
+msgstr "Dies wird Abonnentens von NewPipe oder Youtube importieren."
 
 #: data/resources/ui/import_window.ui:44
 msgid "Cancel"
-msgstr ""
+msgstr "Abbrechen"
 
 #: data/resources/ui/preferences_window.ui:9
 msgid "General"
-msgstr ""
+msgstr "Allgemein"
 
 #: data/resources/ui/preferences_window.ui:13
 msgid "Programs"
-msgstr ""
+msgstr "Programme"
 
 #: data/resources/ui/preferences_window.ui:16
 msgid "Player"
-msgstr ""
+msgstr "Spieler"
 
 #: data/resources/ui/preferences_window.ui:25
-#, fuzzy
 msgid "Downloader"
 msgstr "Herunterladen"
 
 #: data/resources/ui/preferences_window.ui:36
 msgid "APIs"
-msgstr ""
+msgstr "APIs"
 
 #: data/resources/ui/preferences_window.ui:37
 msgid ""
 "For a list of public APIs, see https://github.com/TeamPiped/Piped/wiki/"
 "Instances."
-msgstr ""
+msgstr "Für eine Liste an öffentlichen APIs, siehe https://github.com/TeamPiped/Piped/wiki/Instances."
 
 #: data/resources/ui/preferences_window.ui:40
 msgid "Piped API"
-msgstr ""
+msgstr "Piped API"
 
 #: data/resources/ui/subscription_page.ui:21
-#: data/resources/ui/subscription_page.ui:95 data/resources/ui/window.ui:47
+#: data/resources/ui/subscription_page.ui:98 data/resources/ui/window.ui:47
 msgid "Subscriptions"
 msgstr "Abonnenten"
 
-#: data/resources/ui/subscription_page.ui:56
+#: data/resources/ui/subscription_page.ui:59
 msgid "Base URL"
 msgstr "URL"
 
-#: data/resources/ui/subscription_page.ui:68
+#: data/resources/ui/subscription_page.ui:71
 msgid "Channel ID or Name"
 msgstr "Kanal Name oder ID"
 
@@ -134,12 +133,16 @@ msgstr "Ein Fehler ist aufgetreten"
 msgid "%F %T"
 msgstr "%x %T"
 
+#: src/gui/import_window.rs:83 src/gui/import_window.rs:114
+msgid "Failure to import subscriptions"
+msgstr "Konnte Abbonements nicht importieren"
+
 #: src/gui/preferences_window.rs:49
 msgid ""
 "Note that on Flatpak, there are some more steps required when using a player "
 "external to the Flatpak. For more information, please consult the wiki."
-msgstr ""
+msgstr "Bei Installation mit Flatpak sind außerdem weitere Schritte zur Änderung des Spielers auf ein Programm außerhalb des Flatpaks nötig. Beachten Sie bitte das Wiki."
 
 #: src/gui/preferences_window.rs:74
 msgid "Overwritten by environmental variable."
-msgstr ""
+msgstr "Überschrieben von Umgebungsvariable."

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.5.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-08-01 17:19+0200\n"
+"POT-Creation-Date: 2022-08-05 17:15+0200\n"
 "PO-Revision-Date: 2022-03-05 15:52+0100\n"
 "Last-Translator: Julian Schmidhuber <internationalization@schmiddi.anonaddy."
 "com>\n"
@@ -47,8 +47,57 @@ msgid "Channel Name"
 msgstr "Kanal-Name"
 
 #: data/resources/ui/header_bar.ui:44
+msgid "Settings"
+msgstr ""
+
+#: data/resources/ui/header_bar.ui:48 data/resources/ui/import_window.ui:8
+msgid "Import"
+msgstr ""
+
+#: data/resources/ui/header_bar.ui:52
 msgid "About"
 msgstr "Über"
+
+#: data/resources/ui/import_window.ui:17
+msgid ""
+"This will import your subscriptions from exported data from NewPipe or "
+"Youtube."
+msgstr ""
+
+#: data/resources/ui/import_window.ui:44
+msgid "Cancel"
+msgstr ""
+
+#: data/resources/ui/preferences_window.ui:9
+msgid "General"
+msgstr ""
+
+#: data/resources/ui/preferences_window.ui:13
+msgid "Programs"
+msgstr ""
+
+#: data/resources/ui/preferences_window.ui:16
+msgid "Player"
+msgstr ""
+
+#: data/resources/ui/preferences_window.ui:25
+#, fuzzy
+msgid "Downloader"
+msgstr "Herunterladen"
+
+#: data/resources/ui/preferences_window.ui:36
+msgid "APIs"
+msgstr ""
+
+#: data/resources/ui/preferences_window.ui:37
+msgid ""
+"For a list of public APIs, see https://github.com/TeamPiped/Piped/wiki/"
+"Instances."
+msgstr ""
+
+#: data/resources/ui/preferences_window.ui:40
+msgid "Piped API"
+msgstr ""
 
 #: data/resources/ui/subscription_page.ui:21
 #: data/resources/ui/subscription_page.ui:95 data/resources/ui/window.ui:47
@@ -84,3 +133,13 @@ msgstr "Ein Fehler ist aufgetreten"
 #: src/gui/feed/feed_item_object.rs:88
 msgid "%F %T"
 msgstr "%x %T"
+
+#: src/gui/preferences_window.rs:49
+msgid ""
+"Note that on Flatpak, there are some more steps required when using a player "
+"external to the Flatpak. For more information, please consult the wiki."
+msgstr ""
+
+#: src/gui/preferences_window.rs:74
+msgid "Overwritten by environmental variable."
+msgstr ""

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.5.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-08-05 17:15+0200\n"
+"POT-Creation-Date: 2022-08-08 12:47+0200\n"
 "PO-Revision-Date: 2022-04-22 15:10+0100\n"
 "Last-Translator: Albano Battistella <albano_battistella@hotmail.com>\n"
 "Language-Team: ITALIAN <LL@li.org>\n"
@@ -37,11 +37,11 @@ msgstr "Feed"
 msgid "Filters"
 msgstr "Filtri"
 
-#: data/resources/ui/filter_page.ui:40
+#: data/resources/ui/filter_page.ui:43
 msgid "Title"
 msgstr "Titolo"
 
-#: data/resources/ui/filter_page.ui:45
+#: data/resources/ui/filter_page.ui:48
 msgid "Channel Name"
 msgstr "Nome del canale"
 
@@ -80,9 +80,8 @@ msgid "Player"
 msgstr ""
 
 #: data/resources/ui/preferences_window.ui:25
-#, fuzzy
 msgid "Downloader"
-msgstr "Scaricati"
+msgstr ""
 
 #: data/resources/ui/preferences_window.ui:36
 msgid "APIs"
@@ -99,15 +98,15 @@ msgid "Piped API"
 msgstr ""
 
 #: data/resources/ui/subscription_page.ui:21
-#: data/resources/ui/subscription_page.ui:95 data/resources/ui/window.ui:47
+#: data/resources/ui/subscription_page.ui:98 data/resources/ui/window.ui:47
 msgid "Subscriptions"
 msgstr "Iscrizioni"
 
-#: data/resources/ui/subscription_page.ui:56
+#: data/resources/ui/subscription_page.ui:59
 msgid "Base URL"
 msgstr "URL di base"
 
-#: data/resources/ui/subscription_page.ui:68
+#: data/resources/ui/subscription_page.ui:71
 msgid "Channel ID or Name"
 msgstr "ID o nome del canale"
 
@@ -132,6 +131,10 @@ msgstr "Si è verificato un errore"
 #: src/gui/feed/feed_item_object.rs:88
 msgid "%F %T"
 msgstr "%F %T"
+
+#: src/gui/import_window.rs:83 src/gui/import_window.rs:114
+msgid "Failure to import subscriptions"
+msgstr ""
 
 #: src/gui/preferences_window.rs:49
 msgid ""

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.5.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-08-01 17:19+0200\n"
+"POT-Creation-Date: 2022-08-05 17:15+0200\n"
 "PO-Revision-Date: 2022-04-22 15:10+0100\n"
 "Last-Translator: Albano Battistella <albano_battistella@hotmail.com>\n"
 "Language-Team: ITALIAN <LL@li.org>\n"
@@ -46,8 +46,57 @@ msgid "Channel Name"
 msgstr "Nome del canale"
 
 #: data/resources/ui/header_bar.ui:44
+msgid "Settings"
+msgstr ""
+
+#: data/resources/ui/header_bar.ui:48 data/resources/ui/import_window.ui:8
+msgid "Import"
+msgstr ""
+
+#: data/resources/ui/header_bar.ui:52
 msgid "About"
 msgstr "Informazioni"
+
+#: data/resources/ui/import_window.ui:17
+msgid ""
+"This will import your subscriptions from exported data from NewPipe or "
+"Youtube."
+msgstr ""
+
+#: data/resources/ui/import_window.ui:44
+msgid "Cancel"
+msgstr ""
+
+#: data/resources/ui/preferences_window.ui:9
+msgid "General"
+msgstr ""
+
+#: data/resources/ui/preferences_window.ui:13
+msgid "Programs"
+msgstr ""
+
+#: data/resources/ui/preferences_window.ui:16
+msgid "Player"
+msgstr ""
+
+#: data/resources/ui/preferences_window.ui:25
+#, fuzzy
+msgid "Downloader"
+msgstr "Scaricati"
+
+#: data/resources/ui/preferences_window.ui:36
+msgid "APIs"
+msgstr ""
+
+#: data/resources/ui/preferences_window.ui:37
+msgid ""
+"For a list of public APIs, see https://github.com/TeamPiped/Piped/wiki/"
+"Instances."
+msgstr ""
+
+#: data/resources/ui/preferences_window.ui:40
+msgid "Piped API"
+msgstr ""
 
 #: data/resources/ui/subscription_page.ui:21
 #: data/resources/ui/subscription_page.ui:95 data/resources/ui/window.ui:47
@@ -83,3 +132,13 @@ msgstr "Si è verificato un errore"
 #: src/gui/feed/feed_item_object.rs:88
 msgid "%F %T"
 msgstr "%F %T"
+
+#: src/gui/preferences_window.rs:49
+msgid ""
+"Note that on Flatpak, there are some more steps required when using a player "
+"external to the Flatpak. For more information, please consult the wiki."
+msgstr ""
+
+#: src/gui/preferences_window.rs:74
+msgid "Overwritten by environmental variable."
+msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.5.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-08-05 17:15+0200\n"
+"POT-Creation-Date: 2022-08-08 12:47+0200\n"
 "PO-Revision-Date: 2022-04-22 15:10+0100\n"
 "Last-Translator: Albano Battistella <albano_battistella@hotmail.com>\n"
 "Language-Team: ITALIAN <LL@li.org>\n"
@@ -37,11 +37,11 @@ msgstr "Feed"
 msgid "Filters"
 msgstr "Filtri"
 
-#: data/resources/ui/filter_page.ui:40
+#: data/resources/ui/filter_page.ui:43
 msgid "Title"
 msgstr "Titolo"
 
-#: data/resources/ui/filter_page.ui:45
+#: data/resources/ui/filter_page.ui:48
 msgid "Channel Name"
 msgstr "Nome del canale"
 
@@ -80,9 +80,8 @@ msgid "Player"
 msgstr ""
 
 #: data/resources/ui/preferences_window.ui:25
-#, fuzzy
 msgid "Downloader"
-msgstr "Scaricati"
+msgstr ""
 
 #: data/resources/ui/preferences_window.ui:36
 msgid "APIs"
@@ -99,15 +98,15 @@ msgid "Piped API"
 msgstr ""
 
 #: data/resources/ui/subscription_page.ui:21
-#: data/resources/ui/subscription_page.ui:95 data/resources/ui/window.ui:47
+#: data/resources/ui/subscription_page.ui:98 data/resources/ui/window.ui:47
 msgid "Subscriptions"
 msgstr "Iscrizioni"
 
-#: data/resources/ui/subscription_page.ui:56
+#: data/resources/ui/subscription_page.ui:59
 msgid "Base URL"
 msgstr "URL di base"
 
-#: data/resources/ui/subscription_page.ui:68
+#: data/resources/ui/subscription_page.ui:71
 msgid "Channel ID or Name"
 msgstr "ID o nome del canale"
 
@@ -132,6 +131,10 @@ msgstr "Si è verificato un errore"
 #: src/gui/feed/feed_item_object.rs:88
 msgid "%F %T"
 msgstr "%F %T"
+
+#: src/gui/import_window.rs:83 src/gui/import_window.rs:114
+msgid "Failure to import subscriptions"
+msgstr ""
 
 #: src/gui/preferences_window.rs:49
 msgid ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.5.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-08-01 17:19+0200\n"
+"POT-Creation-Date: 2022-08-05 17:15+0200\n"
 "PO-Revision-Date: 2022-04-22 15:10+0100\n"
 "Last-Translator: Albano Battistella <albano_battistella@hotmail.com>\n"
 "Language-Team: ITALIAN <LL@li.org>\n"
@@ -46,8 +46,57 @@ msgid "Channel Name"
 msgstr "Nome del canale"
 
 #: data/resources/ui/header_bar.ui:44
+msgid "Settings"
+msgstr ""
+
+#: data/resources/ui/header_bar.ui:48 data/resources/ui/import_window.ui:8
+msgid "Import"
+msgstr ""
+
+#: data/resources/ui/header_bar.ui:52
 msgid "About"
 msgstr "Informazioni"
+
+#: data/resources/ui/import_window.ui:17
+msgid ""
+"This will import your subscriptions from exported data from NewPipe or "
+"Youtube."
+msgstr ""
+
+#: data/resources/ui/import_window.ui:44
+msgid "Cancel"
+msgstr ""
+
+#: data/resources/ui/preferences_window.ui:9
+msgid "General"
+msgstr ""
+
+#: data/resources/ui/preferences_window.ui:13
+msgid "Programs"
+msgstr ""
+
+#: data/resources/ui/preferences_window.ui:16
+msgid "Player"
+msgstr ""
+
+#: data/resources/ui/preferences_window.ui:25
+#, fuzzy
+msgid "Downloader"
+msgstr "Scaricati"
+
+#: data/resources/ui/preferences_window.ui:36
+msgid "APIs"
+msgstr ""
+
+#: data/resources/ui/preferences_window.ui:37
+msgid ""
+"For a list of public APIs, see https://github.com/TeamPiped/Piped/wiki/"
+"Instances."
+msgstr ""
+
+#: data/resources/ui/preferences_window.ui:40
+msgid "Piped API"
+msgstr ""
 
 #: data/resources/ui/subscription_page.ui:21
 #: data/resources/ui/subscription_page.ui:95 data/resources/ui/window.ui:47
@@ -83,3 +132,13 @@ msgstr "Si è verificato un errore"
 #: src/gui/feed/feed_item_object.rs:88
 msgid "%F %T"
 msgstr "%F %T"
+
+#: src/gui/preferences_window.rs:49
+msgid ""
+"Note that on Flatpak, there are some more steps required when using a player "
+"external to the Flatpak. For more information, please consult the wiki."
+msgstr ""
+
+#: src/gui/preferences_window.rs:74
+msgid "Overwritten by environmental variable."
+msgstr ""

--- a/po/ru.po
+++ b/po/ru.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.5.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-08-05 17:15+0200\n"
+"POT-Creation-Date: 2022-08-08 12:47+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: David Lapshin <ddaudix@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -38,11 +38,11 @@ msgstr "Лента"
 msgid "Filters"
 msgstr "Фильтры"
 
-#: data/resources/ui/filter_page.ui:40
+#: data/resources/ui/filter_page.ui:43
 msgid "Title"
 msgstr "Название"
 
-#: data/resources/ui/filter_page.ui:45
+#: data/resources/ui/filter_page.ui:48
 msgid "Channel Name"
 msgstr "Название канала"
 
@@ -81,9 +81,8 @@ msgid "Player"
 msgstr ""
 
 #: data/resources/ui/preferences_window.ui:25
-#, fuzzy
 msgid "Downloader"
-msgstr "Скачать"
+msgstr ""
 
 #: data/resources/ui/preferences_window.ui:36
 msgid "APIs"
@@ -100,15 +99,15 @@ msgid "Piped API"
 msgstr ""
 
 #: data/resources/ui/subscription_page.ui:21
-#: data/resources/ui/subscription_page.ui:95 data/resources/ui/window.ui:47
+#: data/resources/ui/subscription_page.ui:98 data/resources/ui/window.ui:47
 msgid "Subscriptions"
 msgstr "Подписки"
 
-#: data/resources/ui/subscription_page.ui:56
+#: data/resources/ui/subscription_page.ui:59
 msgid "Base URL"
 msgstr "Базовый URL"
 
-#: data/resources/ui/subscription_page.ui:68
+#: data/resources/ui/subscription_page.ui:71
 msgid "Channel ID or Name"
 msgstr "ID Канала или имя"
 
@@ -133,6 +132,10 @@ msgstr "Произошла какая-то ошибка"
 #: src/gui/feed/feed_item_object.rs:88
 msgid "%F %T"
 msgstr "%F %T"
+
+#: src/gui/import_window.rs:83 src/gui/import_window.rs:114
+msgid "Failure to import subscriptions"
+msgstr ""
 
 #: src/gui/preferences_window.rs:49
 msgid ""

--- a/po/ru.po
+++ b/po/ru.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.5.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-08-01 17:19+0200\n"
+"POT-Creation-Date: 2022-08-05 17:15+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: David Lapshin <ddaudix@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -47,8 +47,57 @@ msgid "Channel Name"
 msgstr "Название канала"
 
 #: data/resources/ui/header_bar.ui:44
+msgid "Settings"
+msgstr ""
+
+#: data/resources/ui/header_bar.ui:48 data/resources/ui/import_window.ui:8
+msgid "Import"
+msgstr ""
+
+#: data/resources/ui/header_bar.ui:52
 msgid "About"
 msgstr "О Приложении"
+
+#: data/resources/ui/import_window.ui:17
+msgid ""
+"This will import your subscriptions from exported data from NewPipe or "
+"Youtube."
+msgstr ""
+
+#: data/resources/ui/import_window.ui:44
+msgid "Cancel"
+msgstr ""
+
+#: data/resources/ui/preferences_window.ui:9
+msgid "General"
+msgstr ""
+
+#: data/resources/ui/preferences_window.ui:13
+msgid "Programs"
+msgstr ""
+
+#: data/resources/ui/preferences_window.ui:16
+msgid "Player"
+msgstr ""
+
+#: data/resources/ui/preferences_window.ui:25
+#, fuzzy
+msgid "Downloader"
+msgstr "Скачать"
+
+#: data/resources/ui/preferences_window.ui:36
+msgid "APIs"
+msgstr ""
+
+#: data/resources/ui/preferences_window.ui:37
+msgid ""
+"For a list of public APIs, see https://github.com/TeamPiped/Piped/wiki/"
+"Instances."
+msgstr ""
+
+#: data/resources/ui/preferences_window.ui:40
+msgid "Piped API"
+msgstr ""
 
 #: data/resources/ui/subscription_page.ui:21
 #: data/resources/ui/subscription_page.ui:95 data/resources/ui/window.ui:47
@@ -84,3 +133,13 @@ msgstr "Произошла какая-то ошибка"
 #: src/gui/feed/feed_item_object.rs:88
 msgid "%F %T"
 msgstr "%F %T"
+
+#: src/gui/preferences_window.rs:49
+msgid ""
+"Note that on Flatpak, there are some more steps required when using a player "
+"external to the Flatpak. For more information, please consult the wiki."
+msgstr ""
+
+#: src/gui/preferences_window.rs:74
+msgid "Overwritten by environmental variable."
+msgstr ""

--- a/po/tubefeeder.pot
+++ b/po/tubefeeder.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tubefeeder\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-08-01 17:19+0200\n"
+"POT-Creation-Date: 2022-08-05 17:15+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -47,7 +47,55 @@ msgid "Channel Name"
 msgstr ""
 
 #: data/resources/ui/header_bar.ui:44
+msgid "Settings"
+msgstr ""
+
+#: data/resources/ui/header_bar.ui:48 data/resources/ui/import_window.ui:8
+msgid "Import"
+msgstr ""
+
+#: data/resources/ui/header_bar.ui:52
 msgid "About"
+msgstr ""
+
+#: data/resources/ui/import_window.ui:17
+msgid ""
+"This will import your subscriptions from exported data from NewPipe or "
+"Youtube."
+msgstr ""
+
+#: data/resources/ui/import_window.ui:44
+msgid "Cancel"
+msgstr ""
+
+#: data/resources/ui/preferences_window.ui:9
+msgid "General"
+msgstr ""
+
+#: data/resources/ui/preferences_window.ui:13
+msgid "Programs"
+msgstr ""
+
+#: data/resources/ui/preferences_window.ui:16
+msgid "Player"
+msgstr ""
+
+#: data/resources/ui/preferences_window.ui:25
+msgid "Downloader"
+msgstr ""
+
+#: data/resources/ui/preferences_window.ui:36
+msgid "APIs"
+msgstr ""
+
+#: data/resources/ui/preferences_window.ui:37
+msgid ""
+"For a list of public APIs, see https://github.com/TeamPiped/Piped/wiki/"
+"Instances."
+msgstr ""
+
+#: data/resources/ui/preferences_window.ui:40
+msgid "Piped API"
 msgstr ""
 
 #: data/resources/ui/subscription_page.ui:21
@@ -83,4 +131,14 @@ msgstr ""
 
 #: src/gui/feed/feed_item_object.rs:88
 msgid "%F %T"
+msgstr ""
+
+#: src/gui/preferences_window.rs:49
+msgid ""
+"Note that on Flatpak, there are some more steps required when using a player "
+"external to the Flatpak. For more information, please consult the wiki."
+msgstr ""
+
+#: src/gui/preferences_window.rs:74
+msgid "Overwritten by environmental variable."
 msgstr ""

--- a/po/tubefeeder.pot
+++ b/po/tubefeeder.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tubefeeder\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-08-05 17:15+0200\n"
+"POT-Creation-Date: 2022-08-08 12:47+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -38,11 +38,11 @@ msgstr ""
 msgid "Filters"
 msgstr ""
 
-#: data/resources/ui/filter_page.ui:40
+#: data/resources/ui/filter_page.ui:43
 msgid "Title"
 msgstr ""
 
-#: data/resources/ui/filter_page.ui:45
+#: data/resources/ui/filter_page.ui:48
 msgid "Channel Name"
 msgstr ""
 
@@ -99,15 +99,15 @@ msgid "Piped API"
 msgstr ""
 
 #: data/resources/ui/subscription_page.ui:21
-#: data/resources/ui/subscription_page.ui:95 data/resources/ui/window.ui:47
+#: data/resources/ui/subscription_page.ui:98 data/resources/ui/window.ui:47
 msgid "Subscriptions"
 msgstr ""
 
-#: data/resources/ui/subscription_page.ui:56
+#: data/resources/ui/subscription_page.ui:59
 msgid "Base URL"
 msgstr ""
 
-#: data/resources/ui/subscription_page.ui:68
+#: data/resources/ui/subscription_page.ui:71
 msgid "Channel ID or Name"
 msgstr ""
 
@@ -131,6 +131,10 @@ msgstr ""
 
 #: src/gui/feed/feed_item_object.rs:88
 msgid "%F %T"
+msgstr ""
+
+#: src/gui/import_window.rs:83 src/gui/import_window.rs:114
+msgid "Failure to import subscriptions"
 msgstr ""
 
 #: src/gui/preferences_window.rs:49

--- a/src/gui/header_bar.rs
+++ b/src/gui/header_bar.rs
@@ -55,6 +55,7 @@ pub mod imp {
     use gtk::CompositeTemplate;
     use once_cell::sync::Lazy;
 
+    use crate::gui::import_window::ImportWindow;
     use crate::gui::preferences_window::PreferencesWindow;
 
     #[derive(CompositeTemplate, Default)]
@@ -76,6 +77,16 @@ pub mod imp {
                 let settings = PreferencesWindow::new();
                 settings.show();
             });
+            let action_import = SimpleAction::new("import", None);
+            action_import.connect_activate(clone!(@weak obj => move |_, _| {
+                let root = obj
+                    .root()
+                    .expect("HeaderBar to have root")
+                    .downcast::<crate::gui::window::Window>()
+                    .expect("Root to be window");
+                let import = ImportWindow::new(&root);
+                import.show();
+            }));
 
             let action_about = SimpleAction::new("about", None);
             action_about.connect_activate(|_, _| {
@@ -105,8 +116,9 @@ pub mod imp {
 
             let actions = SimpleActionGroup::new();
             obj.insert_action_group("win", Some(&actions));
-            actions.add_action(&action_about);
+            actions.add_action(&action_import);
             actions.add_action(&action_settings);
+            actions.add_action(&action_about);
         }
     }
 

--- a/src/gui/import_window.rs
+++ b/src/gui/import_window.rs
@@ -78,7 +78,13 @@ pub mod imp {
                                 log::trace!("User picked file to import from");
                                 let file = chooser.file();
                                 if let Some(file) = file {
-                                    crate::import::import_newpipe(&obj.imp().joiner.borrow().as_ref().expect("Joiner to be set up"), file);
+                                    if let Err(e) = crate::import::import_newpipe(&obj.imp().joiner.borrow().as_ref().expect("Joiner to be set up"), file) {
+                                        let dialog = gtk::MessageDialog::builder()
+                                            .text(&gettextrs::gettext("Failure to import subscriptions"))
+                                            .secondary_text(&format!("{}", e))
+                                            .message_type(gtk::MessageType::Error).build();
+                                        dialog.show();
+                                    }
                                 }
                             } else {
                                 log::trace!("User did not choose anything to import from");
@@ -103,7 +109,13 @@ pub mod imp {
                                 log::trace!("User picked file to import from");
                                 let file = chooser.file();
                                 if let Some(file) = file {
-                                    crate::import::import_youtube(&obj.imp().joiner.borrow().as_ref().expect("Joiner to be set up"), file);
+                                    if let Err(e) = crate::import::import_youtube(&obj.imp().joiner.borrow().as_ref().expect("Joiner to be set up"), file) {
+                                        let dialog = gtk::MessageDialog::builder()
+                                            .text(&gettextrs::gettext("Failure to import subscriptions"))
+                                            .secondary_text(&format!("{}", e))
+                                            .message_type(gtk::MessageType::Error).build();
+                                        dialog.show();
+                                    }
                                 }
                             } else {
                                 log::trace!("User did not choose anything to import from");

--- a/src/gui/import_window.rs
+++ b/src/gui/import_window.rs
@@ -1,0 +1,121 @@
+use gdk::{glib::Object, subclass::prelude::ObjectSubclassIsExt};
+
+gtk::glib::wrapper! {
+    pub struct ImportWindow(ObjectSubclass<imp::ImportWindow>)
+        @extends gtk::Dialog, gtk::Window, gtk::Widget,
+        @implements gtk::gio::ActionGroup, gtk::gio::ActionMap, gtk::Accessible, gtk::Buildable,
+            gtk::ConstraintTarget, gtk::Native, gtk::Root, gtk::ShortcutManager;
+}
+
+impl ImportWindow {
+    pub fn new(parent: &crate::gui::window::Window) -> Self {
+        let s: Self =
+            Object::new(&[("transient-for", &parent)]).expect("Failed to create ImportWindow");
+        s.imp().joiner.replace(parent.imp().joiner.borrow().clone());
+        s
+    }
+}
+
+pub mod imp {
+    use std::cell::RefCell;
+
+    use gdk_pixbuf::glib::clone;
+    use glib::subclass::InitializingObject;
+    use gtk::builders::FileChooserNativeBuilder;
+    use gtk::glib;
+    use gtk::prelude::*;
+    use gtk::subclass::prelude::*;
+    use gtk::CompositeTemplate;
+    use gtk::FileChooserAction;
+    use gtk::FileFilter;
+    use gtk::ResponseType;
+    use tf_join::Joiner;
+
+    #[derive(CompositeTemplate, Default)]
+    #[template(resource = "/ui/import_window.ui")]
+    pub struct ImportWindow {
+        pub(super) joiner: RefCell<Option<Joiner>>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for ImportWindow {
+        const NAME: &'static str = "TFImportWindow";
+        type Type = super::ImportWindow;
+        type ParentType = gtk::Dialog;
+
+        fn class_init(klass: &mut Self::Class) {
+            Self::bind_template(klass);
+        }
+
+        fn instance_init(obj: &InitializingObject<Self>) {
+            obj.init_template();
+        }
+    }
+
+    impl ObjectImpl for ImportWindow {
+        fn constructed(&self, obj: &Self::Type) {
+            self.parent_constructed(obj);
+        }
+    }
+    impl WidgetImpl for ImportWindow {}
+    impl WindowImpl for ImportWindow {}
+    impl DialogImpl for ImportWindow {
+        fn response(&self, dialog: &Self::Type, response: gtk::ResponseType) {
+            match response {
+                ResponseType::Other(1) => {
+                    log::debug!("Import from NewPipe");
+                    let filter = FileFilter::new();
+                    filter.add_mime_type("application/json");
+                    let chooser = FileChooserNativeBuilder::new()
+                        .transient_for(dialog)
+                        .filter(&filter)
+                        .action(FileChooserAction::Open)
+                        .build();
+                    let obj = self.instance();
+                    chooser.connect_response(
+                        clone!(@strong chooser, @strong obj => move |_, action| {
+                            if action == ResponseType::Accept {
+                                log::trace!("User picked file to import from");
+                                let file = chooser.file();
+                                if let Some(file) = file {
+                                    crate::import::import_newpipe(&obj.imp().joiner.borrow().as_ref().expect("Joiner to be set up"), file);
+                                }
+                            } else {
+                                log::trace!("User did not choose anything to import from");
+                            }
+                        }),
+                    );
+                    chooser.show();
+                }
+                ResponseType::Other(2) => {
+                    log::debug!("Import from YouTube");
+                    let filter = FileFilter::new();
+                    filter.add_mime_type("text/csv");
+                    let chooser = FileChooserNativeBuilder::new()
+                        .transient_for(dialog)
+                        .filter(&filter)
+                        .action(FileChooserAction::Open)
+                        .build();
+                    let obj = self.instance();
+                    chooser.connect_response(
+                        clone!(@strong chooser, @strong obj => move |_, action| {
+                            if action == ResponseType::Accept {
+                                log::trace!("User picked file to import from");
+                                let file = chooser.file();
+                                if let Some(file) = file {
+                                    crate::import::import_youtube(&obj.imp().joiner.borrow().as_ref().expect("Joiner to be set up"), file);
+                                }
+                            } else {
+                                log::trace!("User did not choose anything to import from");
+                            }
+                        }),
+                    );
+                    chooser.show();
+                }
+                _ => {}
+            }
+            dialog.close();
+            self.parent_response(dialog, response)
+        }
+    }
+}

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -21,6 +21,7 @@
 mod feed;
 mod filter;
 mod header_bar;
+mod import_window;
 mod preferences_window;
 mod subscription;
 mod utility;

--- a/src/gui/window.rs
+++ b/src/gui/window.rs
@@ -131,7 +131,7 @@ pub mod imp {
         #[template_child]
         pub(super) subscription_page: TemplateChild<SubscriptionPage>,
 
-        joiner: RefCell<Option<Joiner>>,
+        pub(in crate::gui) joiner: RefCell<Option<Joiner>>,
         playlist_manager: RefCell<Option<PlaylistManager<String, AnyVideo>>>,
         any_subscription_list: RefCell<Option<AnySubscriptionList>>,
         _watchlater_file_manager:

--- a/src/import.rs
+++ b/src/import.rs
@@ -15,17 +15,11 @@ struct NewPipeSubscription {
     url: String,
 }
 
-pub fn import_newpipe(joiner: &Joiner, file: gio::File) {
-    // TODO: Error handling
-    let content: String = String::from_utf8(
-        file.load_contents(gio::Cancellable::NONE)
-            .expect("Loadable file contents")
-            .0,
-    )
-    .expect("File to be string");
+// TODO: Better error handling
+pub fn import_newpipe(joiner: &Joiner, file: gio::File) -> Result<(), Box<dyn std::error::Error>> {
+    let content: String = String::from_utf8(file.load_contents(gio::Cancellable::NONE)?.0)?;
 
-    let deserialized: NewPipeBase =
-        serde_json::from_str(content.as_str()).expect("File to be json");
+    let deserialized: NewPipeBase = serde_json::from_str(content.as_str())?;
 
     let subscription_list = joiner.subscription_list();
     let available_subscriptions: HashSet<String> = subscription_list
@@ -56,16 +50,12 @@ pub fn import_newpipe(joiner: &Joiner, file: gio::File) {
         let sub = YTSubscription::new(&uuid).into();
         subscription_list.add(sub);
     }
+    Ok(())
 }
 
-pub fn import_youtube(joiner: &Joiner, file: gio::File) {
-    // TODO: Error handling
-    let content: String = String::from_utf8(
-        file.load_contents(gio::Cancellable::NONE)
-            .expect("Loadable file contents")
-            .0,
-    )
-    .expect("File to be string");
+// TODO: Better error handling
+pub fn import_youtube(joiner: &Joiner, file: gio::File) -> Result<(), Box<dyn std::error::Error>> {
+    let content: String = String::from_utf8(file.load_contents(gio::Cancellable::NONE)?.0)?;
 
     let subscription_list = joiner.subscription_list();
     let available_subscriptions: HashSet<String> = subscription_list
@@ -96,4 +86,5 @@ pub fn import_youtube(joiner: &Joiner, file: gio::File) {
         let sub = YTSubscription::new(&uuid).into();
         subscription_list.add(sub);
     }
+    Ok(())
 }

--- a/src/import.rs
+++ b/src/import.rs
@@ -1,0 +1,99 @@
+use std::collections::HashSet;
+
+use gdk_pixbuf::{gio, prelude::FileExt};
+use serde::Deserialize;
+use tf_join::{AnySubscription, Joiner};
+use tf_yt::YTSubscription;
+
+#[derive(Deserialize)]
+struct NewPipeBase {
+    subscriptions: Vec<NewPipeSubscription>,
+}
+
+#[derive(Deserialize)]
+struct NewPipeSubscription {
+    url: String,
+}
+
+pub fn import_newpipe(joiner: &Joiner, file: gio::File) {
+    // TODO: Error handling
+    let content: String = String::from_utf8(
+        file.load_contents(gio::Cancellable::NONE)
+            .expect("Loadable file contents")
+            .0,
+    )
+    .expect("File to be string");
+
+    let deserialized: NewPipeBase =
+        serde_json::from_str(content.as_str()).expect("File to be json");
+
+    let subscription_list = joiner.subscription_list();
+    let available_subscriptions: HashSet<String> = subscription_list
+        .iter()
+        .filter_map(|s| {
+            if let AnySubscription::Youtube(s) = s {
+                Some(s)
+            } else {
+                None
+            }
+        })
+        .map(|s| s.id())
+        .collect();
+
+    let uuids: HashSet<String> = deserialized
+        .subscriptions
+        .into_iter()
+        .map(|s| {
+            s.url
+                .strip_prefix("https://www.youtube.com/channel/")
+                .expect("NewPipe URL to start with the youtube URL")
+                .to_owned()
+        })
+        .collect();
+
+    for uuid in uuids.difference(&available_subscriptions) {
+        log::trace!("Subscribing to channel with id {}", uuid);
+        let sub = YTSubscription::new(&uuid).into();
+        subscription_list.add(sub);
+    }
+}
+
+pub fn import_youtube(joiner: &Joiner, file: gio::File) {
+    // TODO: Error handling
+    let content: String = String::from_utf8(
+        file.load_contents(gio::Cancellable::NONE)
+            .expect("Loadable file contents")
+            .0,
+    )
+    .expect("File to be string");
+
+    let subscription_list = joiner.subscription_list();
+    let available_subscriptions: HashSet<String> = subscription_list
+        .iter()
+        .filter_map(|s| {
+            if let AnySubscription::Youtube(s) = s {
+                Some(s)
+            } else {
+                None
+            }
+        })
+        .map(|s| s.id())
+        .collect();
+
+    let uuids: HashSet<String> = content
+        .lines()
+        .skip(1)
+        .map(|s| {
+            s.split(',')
+                .next()
+                .expect("YouTube CSV to have at least one column")
+                .to_owned()
+        })
+        .collect();
+
+    for uuid in uuids.difference(&available_subscriptions) {
+        log::trace!("Subscribing to channel with id {}", uuid);
+        let sub = YTSubscription::new(&uuid).into();
+        subscription_list.add(sub);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ use self::config::{APP_ID, GETTEXT_PACKAGE, LOCALEDIR, RESOURCES_BYTES};
 mod csv_file_manager;
 mod downloader;
 mod gui;
+mod import;
 mod player;
 
 fn init_setting(env: &'static str, value: &str) {


### PR DESCRIPTION
# Licensing 

- [x] I confirm that this is either my code or was released under the terms of a GPLv3-or-later compatible license. Also I agree to release it here under the terms of the GPLv3-or-later.

# Description

This adds a new dialog window where subscriptions can be imported from either NewPipe or Youtube. This will not override the subscriptions, it will add missing subscriptions to the list instead.

Error handling is still TODO and the wiki also needs to be updated.
