### PR TITLE
💄️ Optimize symbolic icon

### DIFF
--- a/data/icons/de.schmidhuberj.tubefeeder-symbolic.svg
+++ b/data/icons/de.schmidhuberj.tubefeeder-symbolic.svg
@@ -1,40 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   height="16px"
-   viewBox="0 0 16 16"
-   width="16px"
-   version="1.1"
-   id="svg12"
-   sodipodi:docname="de.schmidhuberj.tubefeeder.symbolic.svg"
-   inkscape:version="1.2 (dc2aedaf03, 2022-05-15)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg">
-  <sodipodi:namedview
-     id="namedview5"
-     pagecolor="#ffffff"
-     bordercolor="#000000"
-     borderopacity="0.25"
-     inkscape:showpageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1"
-     showgrid="false"
-     inkscape:zoom="14.75"
-     inkscape:cx="7.9661017"
-     inkscape:cy="8"
-     inkscape:window-width="1280"
-     inkscape:window-height="731"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg12" />
-  <defs
-     id="defs16" />
-  <path
-     style="color:#000000;fill:#000000;stroke-linecap:round;stroke-linejoin:round;-inkscape-stroke:none;paint-order:markers fill stroke"
-     d="m 166.04687,-4.0429687 a 1.349765,1.349765 0 0 0 -0.95507,0.9531249 L 161.625,9.8496094 a 1.349765,1.349765 0 0 0 1.6543,1.6542966 l 12.93945,-3.4667966 a 1.349765,1.349765 0 0 0 0.60352,-2.2597657 l -9.47266,-9.4707031 a 1.349765,1.349765 0 0 0 -1.30274,-0.3496093 z m 1.04688,3.9101562 6.16797,6.1679687 -8.42383,2.2558594 z"
-     id="path904"
-     transform="matrix(0.96021384,-0.25728853,0.25728853,0.96021384,-156.83731,46.784287)" />
+<svg height="16px" viewBox="0 0 16 16" width="16px" xmlns="http://www.w3.org/2000/svg" sodipodi:docname="de.schmidhuberj.tubefeeder-symbolic.svg" inkscape:version="1.2.1 (9c6d41e410, 2022-07-14)" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:svg="http://www.w3.org/2000/svg">
+    <sodipodi:namedview pagecolor="#ffffff" bordercolor="#000000" borderopacity="0.25" inkscape:showpageshadow="2" inkscape:pageopacity="0.0" inkscape:pagecheckerboard="0" inkscape:deskcolor="#d1d1d1" showgrid="false" inkscape:zoom="14.75" inkscape:cx="8" inkscape:cy="8" inkscape:window-width="1280" inkscape:window-height="731" inkscape:window-x="0" inkscape:window-y="0" inkscape:window-maximized="1" inkscape:current-layer="svg298"/>
+    <path d="m 1.5628506 0.17912643 a 1.3417832 1.3417832 0 0 0 -0.67184331 1.16093227 l 0.0003035 13.3166103 a 1.3417832 1.3417832 0 0 0 2.01411331 1.162846 l 11.5326719 -6.6580385 a 1.3417832 1.3417832 0 0 0 -0.0019 -2.325137 l -11.532486 -6.65669344 a 1.3417832 1.3417832 0 0 0 -1.3408594 -0.00051963 z m 2.011267 3.48523587 l 7.5095174 4.335621 l -7.508271 4.3334627 z" stroke-linecap="round" stroke-linejoin="round" stroke-width="0.994087" paint-order="markers fill stroke"/>
 </svg>


### PR DESCRIPTION
# Licensing 

- [x] I confirm that this is either my code or was released under the terms of a GPLv3-or-later compatible license. Also I agree to release it here under the terms of the GPLv3-or-later.

# Description

Export symbolic correctly, now it have smaller size

# Linked Issue

None, just learned that it can (and need to) be optimized.
