### PR TITLE
Use `valign` to add vertical padding

### DIFF
--- a/data/resources/ui/preferences_window.ui
+++ b/data/resources/ui/preferences_window.ui
@@ -14,8 +14,10 @@
             <child>
               <object class="AdwActionRow">
                 <property name="title" translatable="yes">Player</property>
+                <property name='valign'>center</property>
                 <child>
                   <object class="GtkEntry" id="entry_player">
+                    <property name='valign'>center</property>
                   </object>
                 </child>
               </object>
@@ -25,6 +27,7 @@
                 <property name="title" translatable="yes">Downloader</property>
                 <child>
                   <object class="GtkEntry" id="entry_downloader">
+                    <property name='valign'>center</property>
                   </object>
                 </child>
               </object>
@@ -40,6 +43,7 @@
                 <property name="title" translatable="yes">Piped API</property>
                 <child>
                   <object class="GtkEntry" id="entry_piped_api">
+                    <property name='valign'>center</property>
                   </object>
                 </child>
               </object>
@@ -50,3 +54,4 @@
     </child>
   </template>
 </interface>
+


### PR DESCRIPTION
# Licensing 

- [x] I confirm that this is either my code or was released under the terms of a GPLv3-or-later compatible license. Also I agree to release it here under the terms of the GPLv3-or-later.

# Description

<!--- Please put a description of your pull request here --->
This uses `valign` to add vertical padding in preferences:
![Screenshot from 2022-08-18 12-55-49](https://user-images.githubusercontent.com/50847364/185453518-34a3135f-b7e8-4d3f-9e12-14c3cd8d1e47.png)


<!--- Please link a issue here in the format "Fixes #n", "Closes #n" or any other valid syntax described [here](https://docs.github.com/en/enterprise/2.13/user/articles/closing-issues-using-keywords). If this pull request has no linked issues, delete this section. --->
