### PR TITLE
Improve AdwAboutWindow

### DIFF
--- a/data/resources/ui/about.ui.in
+++ b/data/resources/ui/about.ui.in
@@ -3,14 +3,15 @@
   <object class="AdwAboutWindow" id="about">
     <property name="application-icon">icon</property>
     <property name="application-name">Tubefeeder</property>
-    <property name="comments">A Youtube, Lbry and Peertube client made for the Pinephone</property>
-    <property name="copyright">© 2022 Julian Schmidhuber</property>
+    <property name="copyright">Copyright © 2022 Julian Schmidhuber</property>
     <property name="developer-name">Julian Schmidhuber</property>
+    <property name="developers">Julian Schmidhuber  &lt;schmidhuberj2@protonmail.com&gt;</property>
     <property name="issue-url">https://github.com/Tubefeeder/Tubefeeder/issues</property>
     <property name="license-type">GTK_LICENSE_GPL_3_0</property>
-    <property name="support-url">https://matrix.to/#/%23tubefeeder:matrix.org</property>
-    <property name="translator-credits" translatable="yes">translators</property>
+    <property name="support-url">https://matrix.to/#/#tubefeeder:matrix.org</property>
+    <property name="translator-credits" translatable="yes">translator-credits</property>
     <property name="website">https://tubefeeder.de</property>
     <property name="version">@VERSION@</property>
+    <property name="artists">David Lapshin &lt;ddaudix@gmail.com&gt;</property>
   </object>
 </interface>

--- a/data/resources/ui/header_bar.ui
+++ b/data/resources/ui/header_bar.ui
@@ -49,7 +49,7 @@
         <attribute name="action">win.import</attribute>
       </item>
       <item>
-        <attribute name="label" translatable="yes">About</attribute>
+        <attribute name="label" translatable="yes">About Tubefeeder</attribute>
         <attribute name="action">win.about</attribute>
       </item>
     </section>

--- a/src/gui/header_bar.rs
+++ b/src/gui/header_bar.rs
@@ -95,6 +95,7 @@ pub mod imp {
                 let about: AboutWindow = builder
                     .object("about")
                     .expect("about.ui to have at least one object about");
+                about.add_link(&gettextrs::gettext("Donate"), "https://www.tubefeeder.de/donate.html");
                 about.show();
             });
 


### PR DESCRIPTION
# Licensing 

- [x] I confirm that this is either my code or was released under the terms of a GPLv3-or-later compatible license. Also I agree to release it here under the terms of the GPLv3-or-later.

# Description

**Disclaimer:** I know nothing about Rust.

This improves AdwAboutWindow by adding translator credits, a donation link. It also removes the comment as GNOME discourages from using it.

I still have to add code and designer contributors, if applicable.

Ref. https://github.com/Tubefeeder/Tubefeeder/issues/95

That being said, is there a way I can build a Flatpak manually so I can test it locally?

<!--- Please link a issue here in the format "Fixes #n", "Closes #n" or any other valid syntax described [here](https://docs.github.com/en/enterprise/2.13/user/articles/closing-issues-using-keywords). If this pull request has no linked issues, delete this section. --->
