### PR TITLE
Change headerbar dropdown menus

### DIFF
--- a/data/resources/ui/header_bar.ui
+++ b/data/resources/ui/header_bar.ui
@@ -33,6 +33,7 @@
         <child type="end">
           <object class="GtkMenuButton">
               <property name="menu-model">menubar</property>
+              <property name="icon-name">open-menu-symbolic</property>
           </object>
         </child>
       </object>
@@ -41,7 +42,7 @@
   <menu id="menubar">
     <section>
       <item>
-        <attribute name="label" translatable="yes">Settings</attribute>
+        <attribute name="label" translatable="yes">Preferences</attribute>
         <attribute name="action">win.settings</attribute>
       </item>
       <item>


### PR DESCRIPTION
# Licensing 

- [x] I confirm that this is either my code or was released under the terms of a GPLv3-or-later compatible license. Also I agree to release it here under the terms of the GPLv3-or-later.

# Description

<!--- Please put a description of your pull request here --->
This MR changes the icon of the dropdown menu to `open-menu-symbolic`, which is the standard for GNOME:

![image](https://user-images.githubusercontent.com/50847364/193957261-f9ff133d-0d5d-4bc4-9365-fd127bc1d880.png)

This also replaces "Settings" to "Preferences".

Ref. https://github.com/Tubefeeder/Tubefeeder/issues/95

<!--- Please link a issue here in the format "Fixes #n", "Closes #n" or any other valid syntax described [here](https://docs.github.com/en/enterprise/2.13/user/articles/closing-issues-using-keywords). If this pull request has no linked issues, delete this section. --->
