### PR TITLE
Add Flatpak build CI

### DIFF
--- a/.github/workflows/build_flatpak.yml
+++ b/.github/workflows/build_flatpak.yml
@@ -1,0 +1,19 @@
+on:
+  push:
+    branches: [master]
+  pull_request:
+name: Build Flatpak
+jobs:
+  flatpak:
+    name: "build-packages"
+    runs-on: ubuntu-latest
+    container:
+      image: bilelmoussaoui/flatpak-github-actions:gnome-43
+      options: --privileged
+    steps:
+    - uses: actions/checkout@v2
+    - uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v4
+      with:
+        bundle: tubefeeder.flatpak
+        manifest-path: build-aux/de.schmidhuberj.tubefeeder.json
+        cache-key: flatpak-builder-${{ github.sha }}

--- a/build-aux/de.schmidhuberj.tubefeeder.json
+++ b/build-aux/de.schmidhuberj.tubefeeder.json
@@ -1,0 +1,49 @@
+{
+    "app-id": "de.schmidhuberj.tubefeeder",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "43",
+    "sdk": "org.gnome.Sdk",
+    "sdk-extensions": [
+        "org.freedesktop.Sdk.Extension.rust-stable"
+    ],
+    "command": "tubefeeder",
+    "finish-args": [
+        "--socket=fallback-x11",
+        "--socket=wayland",
+        "--socket=pulseaudio",
+        "--device=dri",
+        "--share=network",
+        "--filesystem=xdg-data/tubefeeder:create",
+        "--filesystem=xdg-cache/tubefeeder:create",
+        "--filesystem=xdg-config/mpv:ro",
+        "--filesystem=xdg-download",
+        "--talk-name=org.freedesktop.portal.FileChooser",
+        "--talk-name=org.freedesktop.Flatpak"
+    ],
+    "build-options": {
+        "append-path": "/usr/lib/sdk/rust-stable/bin",
+        "env": {
+            "CARGO_HOME": "/run/build/tubefeeder/cargo",
+            "RUST_BACKTRACE": "1"
+        }
+    },
+    "modules": [
+        {
+            "name": "tubefeeder",
+            "buildsystem": "meson",
+            "config-opts": [
+                "-Dflatpak=true"
+            ],
+            "sources": [
+                {
+                    "type": "dir",
+                    "path": "../"
+                },
+                {
+                    "type": "patch",
+                    "path": "player_downloader.diff"
+                }
+            ]
+        }
+    ]
+}

--- a/build-aux/player_downloader.diff
+++ b/build-aux/player_downloader.diff
@@ -1,0 +1,26 @@
+diff --git a/src/downloader.rs b/src/downloader.rs
+index 9014faf..a410828 100644
+--- a/src/downloader.rs
++++ b/src/downloader.rs
+@@ -34,7 +34,7 @@ pub fn download<
+         .unwrap_or("$HOME/Downloads/%(title)s-%(id)s.%(ext)s".to_string());
+     let downloader_str =
+         std::env::var("DOWNLOADER").unwrap_or(format!("youtube-dl --output {}", download_dir));
+-    open_with_output(url, downloader_str, move |output| {
++    open_with_output(url, format!("flatpak-spawn --host {}", downloader_str), move |output| {
+         callback(
+             output
+                 .lines()
+diff --git a/src/player.rs b/src/player.rs
+index 4768002..737648c 100644
+--- a/src/player.rs
++++ b/src/player.rs
+@@ -32,7 +32,7 @@ pub fn play<
+ ) {
+     log::debug!("Playing video with url: {}", url);
+     let player_str = std::env::var("PLAYER").unwrap_or("mpv --ytdl".to_string());
+-    open_with(url, player_str, callback);
++    open_with(url, format!("flatpak-spawn --host {}", player_str), callback);
+ }
+
+ pub fn open_with<


### PR DESCRIPTION
# Licensing 

- [x] I confirm that this is either my code or was released under the terms of a GPLv3-or-later compatible license. Also I agree to release it here under the terms of the GPLv3-or-later.

# Description
This MR will help us test Tubefeeder flatpak without needing to manually build it. GitHub will publish artifacts that we can then download and install locally and test. This also enables us to use GNOME Builder to build it locally and launch the app without installing it.

# Linked Issue

There weren't any discussion prior to opening this MR, so I completely understand if this gets closed.

<!--- Please link a issue here in the format "Fixes #n", "Closes #n" or any other valid syntax described [here](https://docs.github.com/en/enterprise/2.13/user/articles/closing-issues-using-keywords). If this pull request has no linked issues, delete this section. --->
