### PR TITLE
Limit vertical size of feed item buttons

### DIFF
--- a/data/resources/ui/feed_item.ui
+++ b/data/resources/ui/feed_item.ui
@@ -133,12 +133,21 @@
     </child>
     <child>
       <object class="GtkMenuButton">
-          <property name="menu-model">menu</property>
+        <property name="menu-model">menu</property>
+        <property name="halign">center</property>
+        <property name="valign">center</property>
+        <property name="hexpand">false</property>
+        <property name="vexpand">false</property>
       </object>
     </child>
     <child>
       <object class="GtkButton" id="watch_later">
         <property name="icon-name">appointment-new-symbolic</property>
+        <property name="halign">center</property>
+        <property name="valign">center</property>
+        <property name="vexpand">false</property>
+        <property name="hexpand">false</property>
+        <property name="margin-end">7</property>
       </object>
     </child>
   </template>


### PR DESCRIPTION
# Licensing 

- [x] I confirm that this is either my code or was released under the terms of a GPLv3-or-later compatible license. Also I agree to release it here under the terms of the GPLv3-or-later.

# Description

<!--- Please put a description of your pull request here --->

This limits the vertical size of the buttons to be more square like:

![image](https://user-images.githubusercontent.com/60044824/194163741-b98fb6a3-791d-4661-b613-4b06c973a95f.png)


# Linked Issue

<!--- Please link a issue here in the format "Fixes #n", "Closes #n" or any other valid syntax described [here](https://docs.github.com/en/enterprise/2.13/user/articles/closing-issues-using-keywords). If this pull request has no linked issues, delete this section. --->
I guess #95 somewhat?