### PR TITLE
Add triple dots on Import button

### DIFF
--- a/data/resources/ui/header_bar.ui
+++ b/data/resources/ui/header_bar.ui
@@ -46,7 +46,7 @@
         <attribute name="action">win.settings</attribute>
       </item>
       <item>
-        <attribute name="label" translatable="yes">Import</attribute>
+        <attribute name="label" translatable="yes">Import…</attribute>
         <attribute name="action">win.import</attribute>
       </item>
       <item>


### PR DESCRIPTION
# Licensing 

- [x] I confirm that this is either my code or was released under the terms of a GPLv3-or-later compatible license. Also I agree to release it here under the terms of the GPLv3-or-later.

# Description

<!--- Please put a description of your pull request here --->

This adds triple dots next to the Import button. This is the standard for GNOME applications.

# Linked Issue
Ref. https://github.com/Tubefeeder/Tubefeeder/issues/95

<!--- Please link a issue here in the format "Fixes #n", "Closes #n" or any other valid syntax described [here](https://docs.github.com/en/enterprise/2.13/user/articles/closing-issues-using-keywords). If this pull request has no linked issues, delete this section. --->
