### PR TITLE
Allow network access during build time

### DIFF
--- a/build-aux/de.schmidhuberj.tubefeeder.json
+++ b/build-aux/de.schmidhuberj.tubefeeder.json
@@ -22,6 +22,9 @@
     ],
     "build-options": {
         "append-path": "/usr/lib/sdk/rust-stable/bin",
+        "build-args": [
+            "--share=network"
+        ],
         "env": {
             "CARGO_HOME": "/run/build/tubefeeder/cargo",
             "RUST_BACKTRACE": "1"


### PR DESCRIPTION
# Licensing 

- [x] I confirm that this is either my code or was released under the terms of a GPLv3-or-later compatible license. Also I agree to release it here under the terms of the GPLv3-or-later.

# Description

This allows network access during build time so it can download all dependencies.

<!--- Please link a issue here in the format "Fixes #n", "Closes #n" or any other valid syntax described [here](https://docs.github.com/en/enterprise/2.13/user/articles/closing-issues-using-keywords). If this pull request has no linked issues, delete this section. --->
