### PR TITLE
Add status pages

### DIFF
--- a/data/resources/ui/feed_page.ui
+++ b/data/resources/ui/feed_page.ui
@@ -54,6 +54,26 @@
         </child>
         <child>
           <object class="TFFeedList" id="feed_list">
+            <binding name="visible">
+              <closure function="not" type="gboolean">
+                <lookup name="is-empty">
+                  feed_list
+                </lookup>
+              </closure>
+            </binding>
+          </object>
+        </child>
+        <child>
+          <object class="AdwStatusPage">
+            <property name="title" translatable="yes">No Videos Found</property>
+            <property name="description" translatable="yes">Are you subscribed to channels?</property>
+            <property name="icon-name">go-home-symbolic</property>
+            <property name="vexpand">True</property>
+            <binding name="visible">
+              <lookup name="is-empty">
+                feed_list
+              </lookup>
+            </binding>
           </object>
         </child>
       </object>

--- a/data/resources/ui/filter_page.ui
+++ b/data/resources/ui/filter_page.ui
@@ -57,6 +57,26 @@
         </child>
         <child>
           <object class="TFFilterList" id="filter_list">
+            <binding name="visible">
+              <closure function="not" type="gboolean">
+                <lookup name="is-empty">
+                  filter_list
+                </lookup>
+              </closure>
+            </binding>
+          </object>
+        </child>
+        <child>
+          <object class="AdwStatusPage">
+            <property name="title" translatable="yes">No Filters</property>
+            <property name="description" translatable="yes">How about adding some filters?</property>
+            <property name="icon-name">funnel-symbolic</property>
+            <property name="vexpand">True</property>
+            <binding name="visible">
+              <lookup name="is-empty">
+                filter_list
+              </lookup>
+            </binding>
           </object>
         </child>
       </object>

--- a/data/resources/ui/subscription_page.ui
+++ b/data/resources/ui/subscription_page.ui
@@ -81,6 +81,26 @@
                 <child>
                   <object class="TFSubscriptionList" id="subscription_list">
                     <signal name="go-to-videos" handler="handle_go_to_videos_page" swapped="true"/>
+                    <binding name="visible">
+                      <closure function="not" type="gboolean">
+                        <lookup name="is-empty">
+                          subscription_list
+                        </lookup>
+                      </closure>
+                    </binding>
+                  </object>
+                </child>
+                <child>
+                  <object class="AdwStatusPage">
+                    <property name="title" translatable="yes">No Subscriptions</property>
+                    <property name="description" translatable="yes">How about subscribing to some channels?</property>
+                    <property name="icon-name">library-artists-symbolic</property>
+                    <property name="vexpand">True</property>
+                    <binding name="visible">
+                      <lookup name="is-empty">
+                        subscription_list
+                      </lookup>
+                    </binding>
                   </object>
                 </child>
               </object>

--- a/data/resources/ui/watch_later.ui
+++ b/data/resources/ui/watch_later.ui
@@ -29,7 +29,7 @@
         </child>
         <child>
           <object class="AdwStatusPage">
-            <property name="title" translatable="yes">Everything watched</property>
+            <property name="title" translatable="yes">Everything Watched</property>
             <property name="description" translatable="yes">How about going outside?</property>
             <property name="icon-name">alarm-symbolic</property>
             <property name="vexpand">True</property>

--- a/data/resources/ui/watch_later.ui
+++ b/data/resources/ui/watch_later.ui
@@ -18,6 +18,26 @@
         </child>
         <child>
           <object class="TFFeedList" id="feed_page">
+            <binding name="visible">
+              <closure function="not" type="gboolean">
+                <lookup name="is-empty">
+                  feed_page
+                </lookup>
+            </closure>
+            </binding>
+          </object>
+        </child>
+        <child>
+          <object class="AdwStatusPage">
+            <property name="title" translatable="yes">Everything watched</property>
+            <property name="description" translatable="yes">How about going outside?</property>
+            <property name="icon-name">alarm-symbolic</property>
+            <property name="vexpand">True</property>
+            <binding name="visible">
+              <lookup name="is-empty">
+                feed_page
+              </lookup>
+            </binding>
           </object>
         </child>
       </object>

--- a/src/gui/feed/feed_list.rs
+++ b/src/gui/feed/feed_list.rs
@@ -77,6 +77,7 @@ impl FeedList {
         let _ = self.activate_action("feed.more", None);
 
         self.set_more_available();
+        self.notify("is-empty");
     }
 
     pub fn prepend(&self, new_item: VideoObject) {
@@ -90,6 +91,7 @@ impl FeedList {
         loaded_count.set(loaded_count.get() + 1);
 
         self.set_more_available();
+        self.notify("is-empty");
     }
 
     pub fn remove(&self, new_item: VideoObject) {
@@ -111,6 +113,7 @@ impl FeedList {
         }
 
         self.set_more_available();
+        self.notify("is-empty");
     }
 
     pub fn set_playlist_manager(&self, playlist_manager: PlaylistManager<String, AnyVideo>) {
@@ -228,13 +231,22 @@ pub mod imp {
 
         fn properties() -> &'static [ParamSpec] {
             static PROPERTIES: Lazy<Vec<ParamSpec>> = Lazy::new(|| {
-                vec![ParamSpecBoolean::new(
-                    "more-available",
-                    "more-available",
-                    "more-available",
-                    false,
-                    ParamFlags::READWRITE,
-                )]
+                vec![
+                    ParamSpecBoolean::new(
+                        "more-available",
+                        "more-available",
+                        "more-available",
+                        false,
+                        ParamFlags::READWRITE,
+                    ),
+                    ParamSpecBoolean::new(
+                        "is-empty",
+                        "is-empty",
+                        "is-empty",
+                        false,
+                        ParamFlags::READABLE,
+                    ),
+                ]
             });
             PROPERTIES.as_ref()
         }
@@ -254,6 +266,7 @@ pub mod imp {
         fn property(&self, _obj: &Self::Type, _id: usize, pspec: &ParamSpec) -> Value {
             match pspec.name() {
                 "more-available" => self.more_available.get().to_value(),
+                "is-empty" => (self.model.borrow().n_items() == 0).to_value(),
                 _ => unimplemented!(),
             }
         }

--- a/src/gui/filter/filter_page.rs
+++ b/src/gui/filter/filter_page.rs
@@ -61,6 +61,7 @@ pub mod imp {
     use tf_join::AnyVideoFilter;
 
     use crate::gui::filter::filter_list::FilterList;
+    use crate::gui::utility::Utility;
 
     #[derive(CompositeTemplate, Default)]
     #[template(resource = "/ui/filter_page.ui")]
@@ -140,6 +141,7 @@ pub mod imp {
 
         fn class_init(klass: &mut Self::Class) {
             Self::bind_template(klass);
+            Utility::bind_template_callbacks(klass);
         }
 
         fn instance_init(obj: &InitializingObject<Self>) {

--- a/src/gui/subscription/subscription_page.rs
+++ b/src/gui/subscription/subscription_page.rs
@@ -83,6 +83,7 @@ pub mod imp {
     use crate::gui::subscription::platform::PlatformObject;
     use crate::gui::subscription::subscription_item_object::SubscriptionObject;
     use crate::gui::subscription::subscription_list::SubscriptionList;
+    use crate::gui::utility::Utility;
 
     #[derive(CompositeTemplate, Default)]
     #[template(resource = "/ui/subscription_page.ui")]
@@ -257,6 +258,7 @@ pub mod imp {
         fn class_init(klass: &mut Self::Class) {
             Self::bind_template(klass);
             Self::bind_template_callbacks(klass);
+            Utility::bind_template_callbacks(klass);
         }
 
         fn instance_init(obj: &InitializingObject<Self>) {

--- a/src/gui/watch_later.rs
+++ b/src/gui/watch_later.rs
@@ -58,6 +58,7 @@ pub mod imp {
 
     use crate::gui::feed::feed_item_object::VideoObject;
     use crate::gui::feed::feed_list::FeedList;
+    use crate::gui::utility::Utility;
 
     #[derive(CompositeTemplate, Default)]
     #[template(resource = "/ui/watch_later.ui")]
@@ -127,6 +128,7 @@ pub mod imp {
 
         fn class_init(klass: &mut Self::Class) {
             Self::bind_template(klass);
+            Utility::bind_template_callbacks(klass);
         }
 
         fn instance_init(obj: &InitializingObject<Self>) {


### PR DESCRIPTION
# Licensing 

- [x] I confirm that this is either my code or was released under the terms of a GPLv3-or-later compatible license. Also I agree to release it here under the terms of the GPLv3-or-later.

# Description

Had a little bit of time and implemented showing status pages if a page was empty. @TheEvilSkeleton if you have time feel free to review. The texts and iconds should probably be discussed a little more.

E.g. watch-later page:

![tubefeeder-status-page](https://user-images.githubusercontent.com/48252573/201482836-a9c33574-b18e-4216-94a7-d6f57c3d9c25.png)


# Linked Issue

Related to #95.
