### PR TITLE
Use dialogs instead of weird dropdowns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -737,9 +737,9 @@ dependencies = [
 
 [[package]]
 name = "gtk4"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64f0c2a3d80e899dc3febddad5bac193ffcf74a0fd7e31037f30dd34d6f7396"
+checksum = "4e8ae5aef2793bc3551b5e5e3fa062a5de54bb1eccf10dfa4effe9e4384fbbbc"
 dependencies = [
  "bitflags",
  "cairo-rs",
@@ -760,9 +760,9 @@ dependencies = [
 
 [[package]]
 name = "gtk4-macros"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fafbcc920af4eb677d7d164853e7040b9de5a22379c596f570190c675d45f7a7"
+checksum = "d9a4a8077b3a392dd7d637924529e1213d2e0c8e4d531177bc3355e86c257a54"
 dependencies = [
  "anyhow",
  "proc-macro-crate",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-gtk = { version = "0.4.8", package = "gtk4" }
+gtk = { version = "0.4.9", package = "gtk4" }
 gdk-pixbuf = "0.15.10"
 gdk = { version = "0.4.8", package = "gdk4" }
 pango = "0.15.10"

--- a/data/resources/ui/filter_page.ui
+++ b/data/resources/ui/filter_page.ui
@@ -31,31 +31,6 @@
           </object>
         </child>
         <child>
-          <object class="GtkBox">
-            <property name="spacing">8</property>
-            <binding name="visible">
-              <lookup name="add-visible" type="TFFilterPage">
-              </lookup>
-            </binding>
-
-            <child>
-              <object class="GtkEntry" id="entry_title">
-                <property name="placeholder-text" translatable="yes">Title</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkEntry" id="entry_channel">
-                <property name="placeholder-text" translatable="yes">Channel Name</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkButton" id="btn_add_filter">
-                <property name="icon-name">go-next-symbolic</property>
-              </object>
-            </child>
-          </object>
-        </child>
-        <child>
           <object class="TFFilterList" id="filter_list">
             <binding name="visible">
               <closure function="not" type="gboolean">
@@ -82,4 +57,31 @@
       </object>
     </child>
   </template>
+
+  <object class="AdwMessageDialog" id="dialog_add">
+    <property name="heading" translatable="yes">Add Filter</property>
+    <property name="default-response">add</property>
+    <property name="hide-on-close">True</property>
+    <property name="extra-child">
+      <object class="GtkBox">
+        <property name="orientation">vertical</property>
+        <property name="spacing">5</property>
+        <child>
+          <object class="GtkEntry" id="entry_title">
+            <property name="placeholder-text" translatable="yes">Title</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkEntry" id="entry_channel">
+            <property name="placeholder-text" translatable="yes">Channel Name</property>
+          </object>
+        </child>
+      </object>
+    </property>
+    <signal name="response" handler="handle_add_filter" swapped="true"/>
+    <responses>
+      <response id="cancel" translatable="yes">Cancel</response>
+      <response id="add" translatable="yes" appearance="suggested">Add</response>
+    </responses>
+  </object>
 </interface>

--- a/data/resources/ui/subscription_page.ui
+++ b/data/resources/ui/subscription_page.ui
@@ -36,49 +36,6 @@
                   </object>
                 </child>
                 <child>
-                  <object class="GtkBox">
-                    <property name="spacing">8</property>
-                    <binding name="visible">
-                      <lookup name="add-visible" type="TFSubscriptionPage">
-                      </lookup>
-                    </binding>
-
-                    <child>
-                      <object class="GtkDropDown" id="dropdown_platform">
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkEntry" id="entry_url">
-                        <binding name="visible">
-                          <closure function="url_visible" type="gboolean">
-                            <lookup name="selected-item">
-                              dropdown_platform
-                            </lookup>
-                          </closure>
-                        </binding>
-                        <property name="placeholder-text" translatable="yes">Base URL</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkEntry" id="entry_name_id">
-                        <binding name="visible">
-                          <closure function="name_visible" type="gboolean">
-                            <lookup name="selected-item">
-                              dropdown_platform
-                            </lookup>
-                          </closure>
-                        </binding>
-                        <property name="placeholder-text" translatable="yes">Channel ID or Name</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkButton" id="btn_add_subscription">
-                        <property name="icon-name">go-next-symbolic</property>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-                <child>
                   <object class="TFSubscriptionList" id="subscription_list">
                     <signal name="go-to-videos" handler="handle_go_to_videos_page" swapped="true"/>
                     <binding name="visible">
@@ -141,4 +98,51 @@
       </object>
     </child>
   </template>
+
+  <object class="AdwMessageDialog" id="dialog_add">
+    <property name="heading" translatable="yes">Add Subscription</property>
+    <property name="default-response">add</property>
+    <property name="hide-on-close">True</property>
+    <property name="extra-child">
+      <object class="GtkBox">
+        <property name="orientation">vertical</property>
+        <property name="spacing">5</property>
+
+        <child>
+          <object class="GtkDropDown" id="dropdown_platform">
+          </object>
+        </child>
+        <child>
+          <object class="GtkEntry" id="entry_url">
+            <binding name="visible">
+              <closure function="url_visible" type="gboolean">
+                <lookup name="selected-item">
+                  dropdown_platform
+                </lookup>
+              </closure>
+            </binding>
+            <property name="placeholder-text" translatable="yes">Base URL</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkEntry" id="entry_name_id">
+            <binding name="visible">
+              <closure function="name_visible" type="gboolean">
+                <lookup name="selected-item">
+                  dropdown_platform
+                </lookup>
+              </closure>
+            </binding>
+            <property name="placeholder-text" translatable="yes">Channel ID or Name</property>
+          </object>
+        </child>
+
+      </object>
+    </property>
+    <signal name="response" handler="handle_add_subscription" swapped="true"/>
+    <responses>
+      <response id="cancel" translatable="yes">Cancel</response>
+      <response id="add" translatable="yes" appearance="suggested">Add</response>
+    </responses>
+  </object>
 </interface>


### PR DESCRIPTION
# Licensing 

- [x] I confirm that this is either my code or was released under the terms of a GPLv3-or-later compatible license. Also I agree to release it here under the terms of the GPLv3-or-later.

# Description

For adding filters or subscriptions, Tubefeeder had weird drop-down things. Now, a `libadwaita::MessageDialog` is used instead.

For example the subscribe-dialog:
![tubefeeder_subscribe_dialog](https://user-images.githubusercontent.com/48252573/223759450-ca1b1dc2-562a-4fc6-9604-9f8565934eca.png)


# Linked Issue

Related to #95.
