### PR TITLE
:package: Update flatpak to Gnome runtime 44

### DIFF
--- a/build-aux/de.schmidhuberj.tubefeeder.json
+++ b/build-aux/de.schmidhuberj.tubefeeder.json
@@ -1,7 +1,7 @@
 {
     "app-id": "de.schmidhuberj.tubefeeder",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "43",
+    "runtime-version": "44",
     "sdk": "org.gnome.Sdk",
     "sdk-extensions": [
         "org.freedesktop.Sdk.Extension.rust-stable"


### PR DESCRIPTION
# Licensing 

- [x] I confirm that this is either my code or was released under the terms of a GPLv3-or-later compatible license. Also I agree to release it here under the terms of the GPLv3-or-later.

# Description

Updates the flatpak package runtime to the latest Gnome runtime, which is `44` at the moment.
