### PR TITLE
Show only videos from yesterday

### DIFF
--- a/data/de.schmidhuberj.tubefeeder.gschema.xml
+++ b/data/de.schmidhuberj.tubefeeder.gschema.xml
@@ -26,5 +26,10 @@
       <default>"https://pipedapi.kavin.rocks"</default>
       <summary>The piped api url</summary>
     </key>
+
+    <key name="only-videos-yesterday" type="b">
+      <default>false</default>
+      <summary>Only show videos of yesterday.</summary>
+    </key>
   </schema>
 </schemalist>

--- a/data/resources/ui/preferences_window.ui
+++ b/data/resources/ui/preferences_window.ui
@@ -34,6 +34,22 @@
             </child>
           </object>
         </child>
+        <child>
+          <object class="AdwPreferencesGroup">
+            <property name="title" translatable="yes">Other</property>
+            <child>
+              <object class="AdwActionRow">
+                <property name="title" translatable="yes">Show only Videos from Yesterday</property>
+                <child>
+                  <object class="GtkSwitch" id="switch_only_videos_yesterday">
+                    <property name="valign">center</property>
+                    <property name="halign">center</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
       </object>
     </child>
   </template>

--- a/src/gui/feed/feed_item_object.rs
+++ b/src/gui/feed/feed_item_object.rs
@@ -99,6 +99,10 @@ impl VideoObject {
         self.imp().video.borrow().clone()
     }
 
+    pub fn uploaded(&self) -> Option<chrono::NaiveDateTime> {
+        self.video().map(|v| v.uploaded())
+    }
+
     pub fn play(&self) {
         self.set_property("playing", true);
         let (sender, receiver) = MainContext::channel(PRIORITY_DEFAULT);

--- a/src/gui/preferences_window.rs
+++ b/src/gui/preferences_window.rs
@@ -21,6 +21,7 @@ pub mod imp {
     use gtk::prelude::*;
     use gtk::subclass::prelude::*;
     use gtk::CompositeTemplate;
+    use gtk::Switch;
     use libadwaita::subclass::prelude::AdwWindowImpl;
     use libadwaita::subclass::prelude::PreferencesWindowImpl;
     use libadwaita::traits::PreferencesGroupExt;
@@ -39,6 +40,9 @@ pub mod imp {
 
         #[template_child]
         group_programs: TemplateChild<libadwaita::PreferencesGroup>,
+
+        #[template_child]
+        switch_only_videos_yesterday: TemplateChild<Switch>,
 
         settings: Settings,
     }
@@ -67,6 +71,15 @@ pub mod imp {
             self.init_string_setting("PLAYER", "player", self.entry_player.get());
             self.init_string_setting("DOWNLOADER", "downloader", self.entry_downloader.get());
             self.init_string_setting("PIPED_API_URL", "piped-url", self.entry_piped_api.get());
+
+            self.settings
+                .bind(
+                    "only-videos-yesterday",
+                    &self.switch_only_videos_yesterday.get(),
+                    "active",
+                )
+                .flags(SettingsBindFlags::DEFAULT)
+                .build();
         }
     }
 
@@ -83,6 +96,7 @@ pub mod imp {
                 entry_player: TemplateChild::default(),
                 entry_downloader: TemplateChild::default(),
                 entry_piped_api: TemplateChild::default(),
+                switch_only_videos_yesterday: Default::default(),
             }
         }
 


### PR DESCRIPTION
# Licensing 

- [x] I confirm that this is either my code or was released under the terms of a GPLv3-or-later compatible license. Also I agree to release it here under the terms of the GPLv3-or-later.

# Description

This adds the option to only show videos that were uploaded "yesterday" (i.e. the previous day to loading the video list). This will lead to the change that videos will only update once a day and that videos of previous days will be removed (except of course if the video was added to the watch later list).